### PR TITLE
Listing behaviour was incorrect. . .

### DIFF
--- a/package.json
+++ b/package.json
@@ -413,13 +413,13 @@
         },
         {
           "command": "tekton.taskrun.list",
-          "when": "view == tektonPipelineExplorer && viewItem == taskrun",
-          "group": "c1"
+          "when": "view == tektonPipelineExplorer && viewItem == pipelinerun",
+          "group": "c1@4"
         },
         {
           "command": "tekton.taskrun.logs",
           "when": "view == tektonPipelineExplorer && viewItem == taskrun",
-          "group": "c1@2"
+          "group": "c1"
         },
         {
           "command": "tekton.taskrun.delete",

--- a/src/tekton/clustertask.ts
+++ b/src/tekton/clustertask.ts
@@ -17,7 +17,7 @@ export class ClusterTask extends TektonItem {
 /*         const clustertasks = await ClusterTask.getTektonCmdData(treeItem,
             "From which pipeline you want to list ClusterTasks",
             "Select Pipeline you want to describe"); */
-            if (clustertasks) { ClusterTask.tkn.executeInTerminal(Command.listClusterTasksinTerminal(clustertasks.getName())); }
+            if (clustertasks) { ClusterTask.tkn.executeInTerminal(Command.listClusterTasksinTerminal("default")); }
     }
 
     static async delete(clustertask: TektonNode): Promise<void> {

--- a/src/tekton/task.ts
+++ b/src/tekton/task.ts
@@ -16,7 +16,7 @@ export class Task extends TektonItem {
     static async list(task: TektonNode): Promise<void> {
 /*         const task = await Task.getTektonCmdData(treeItem,
             "Which task do you want to list"); */
-        if (task) { Task.tkn.executeInTerminal(Command.listTasksinTerminal(task.getName())); }
+        if (task) { Task.tkn.executeInTerminal(Command.listTasksinTerminal("default")); }
     }
 
     static async delete(task: TektonNode): Promise<void> {

--- a/src/tekton/taskrun.ts
+++ b/src/tekton/taskrun.ts
@@ -16,7 +16,7 @@ export class TaskRun extends TektonItem {
 /*         const taskrun = await TaskRun.getTektonCmdData(treeItem,
             "From which pipeline do you want to list a Taskrun",
             "Select Taskruns you want to list"); */
-        if (taskrun) { TaskRun.tkn.executeInTerminal(Command.listTaskRunsInTerminal(taskrun.getName())); }
+        if (taskrun) { TaskRun.tkn.executeInTerminal(Command.listTaskRunsInTerminal("default")); }
     }
 
     static async logs(taskrun: TektonNode): Promise<void> {

--- a/src/tkn.ts
+++ b/src/tkn.ts
@@ -7,8 +7,6 @@ import { ToolsConfig } from './tools';
 import format = require('string-format');
 import { PipelineExplorer } from './pipeline/pipelineExplorer';
 import bs = require('binary-search');
-import { pipeline } from 'stream';
-
 
 export interface TektonNode extends QuickPickItem {
     contextValue: string;
@@ -94,27 +92,27 @@ export class Command {
         return `tkn pipelinerun logs ${name}`;
     }
     @verbose
-    static listTasks(name: string) {
-        return `tkn task list ${name} -o json`;
+    static listTasks(namespace: string) {
+        return `tkn task list -n ${namespace} -o json`;
     }
     @verbose
-    static listTasksinTerminal(name: string) {
-        return `tkn task list ${name}`;
+    static listTasksinTerminal(namespace: string) {
+        return `tkn task list -n ${namespace} -o json`;
     }
     @verbose
-    static listTaskRuns(name: string) {
-        return `tkn taskrun list ${name} -o json`;
+    static listTaskRuns(namespace: string) {
+        return `tkn taskrun list -n ${namespace} -o json`;
     }
     @verbose
-    static listTaskRunsInTerminal(name: string) {
-        return `tkn taskrun list ${name}`;
+    static listTaskRunsInTerminal(namespace: string) {
+        return `tkn taskrun list -n ${namespace}`;
     }
     @verbose
-    static listClusterTasks(name: string) {
-        return `tkn clustertask list ${name} -o json`;
+    static listClusterTasks(namespace: string) {
+        return `tkn clustertask list -n ${namespace} -o json`;
     }
-    static listClusterTasksinTerminal(name: string) {
-        return `tkn clustertask list ${name}`;
+    static listClusterTasksinTerminal(namespace: string) {
+        return `tkn clustertask list -n ${namespace}`;
     }
     @verbose
     static showTaskRunLogs(name: string) {
@@ -369,7 +367,7 @@ export class TknImpl implements Tkn {
     }
 
     async _getTaskRuns(pipelinerun: TektonNode): Promise<TektonNode[]> {
-        const result: cliInstance.CliExitData = await this.execute(Command.listTaskRuns(""));
+        const result: cliInstance.CliExitData = await this.execute(Command.listTaskRuns("default"));
         if (result.stderr) {
             console.log(result + " Std.err when processing pipelines");
             return [new TektonNodeImpl(pipelinerun, result.stderr, ContextType.TASKRUN, this, TreeItemCollapsibleState.Expanded)];
@@ -389,7 +387,7 @@ export class TknImpl implements Tkn {
 
     async getTasksWithTkn(task: TektonNode): Promise<TektonNode[]> {
         let data: any[] = [];
-        const result: cliInstance.CliExitData = await this.execute(Command.listTasks(""));
+        const result: cliInstance.CliExitData = await this.execute(Command.listTasks("default"));
         if (result.stderr) {
             console.log(result + "Std.err when processing tasks");
             return [new TektonNodeImpl(task, result.stderr, ContextType.TASK, this, TreeItemCollapsibleState.Expanded)];
@@ -450,7 +448,7 @@ export class TknImpl implements Tkn {
     }
 
     async _getClusterTasks(clustertask: TektonNode): Promise<TektonNode[]> {
-        const result: cliInstance.CliExitData = await this.execute(Command.listClusterTasks(""));
+        const result: cliInstance.CliExitData = await this.execute(Command.listClusterTasks("default"));
         let data: any[] = [];
         try {
             data = JSON.parse(result.stdout).items;


### PR DESCRIPTION
However, looking further into CLI behaviour, I'm not sure that things are arranged as they should be in the extension.
In the current Tekton Pipelines View:
```
Pipelines 
    > Actual Pipelines
        > PipelineRuns 
            > Taskruns
Tasks
    > Actual Tasks
ClusterTasks
    > Actual ClusterTasks
```
However, this is not how the CLI seems to organize things. Following from the view above, I would have thought `tkn taskruns list pipelinerun-1` would return all of the taskruns in pipelinerun-1 but actually the CLI functionality requires that you call `tkn taskruns list task-1` in order to get the taskruns associated with task-`. . .so now I am thinking the Pipeline View is actually incorrect.
Should TaskRuns fall under the Tasks heading instead of PipelineRuns? 