### PR TITLE
Fix Tekton Image and Close div for PipelineRun/TaskRun Running in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Visual Studio Code Tekton Pipelines Extension  <img src="https://github.com/redhat-developer/vscode-tekton/blob/master/images/tekton.png" alt="tekton" width="50"/>
+# Visual Studio Code Tekton Pipelines Extension  <img src="https://raw.githubusercontent.com/redhat-developer/vscode-tekton/master/images/tekton.png" alt="tekton" width="50"/>
 
 [![Build Status](https://travis-ci.com/redhat-developer/vscode-tekton.svg?branch=master)](https://travis-ci.com/redhat-developer/vscode-tekton)
 [![Unit Tests Code Coverage](https://codecov.io/gh/redhat-developer/vscode-tekton/branch/master/graph/badge.svg)](https://codecov.io/gh/redhat-developer/vscode-tekton/branch/master/graph/badge.svg)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Visual Studio Code Tekton Pipelines Extension  <img src="https://github.com/redhat-developer/vscode-tekton/images/tekton.png" alt="tekton" width="50"/>
+# Visual Studio Code Tekton Pipelines Extension  <img src="https://github.com/redhat-developer/vscode-tekton/blob/master/images/tekton.png" alt="tekton" width="50"/>
 
 [![Build Status](https://travis-ci.com/redhat-developer/vscode-tekton.svg?branch=master)](https://travis-ci.com/redhat-developer/vscode-tekton)
 [![Unit Tests Code Coverage](https://codecov.io/gh/redhat-developer/vscode-tekton/branch/master/graph/badge.svg)](https://codecov.io/gh/redhat-developer/vscode-tekton/branch/master/graph/badge.svg)
@@ -85,6 +85,3 @@ Feedback & Questions
 ====================
 If you discover an issue please file a bug and we will fix it as soon as possible.
 * File a bug in [GitHub Issues](https://github.com/redhat-developer/vscode-tekton/issues).
-
-
-

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Development of the Tekton Pipelines Extension is largely following development o
 <div><img src="https://raw.githubusercontent.com/redhat-developer/vscode-tekton/master/images/pipe.png" width="15" height="15" /><span style="margin: 20px">Pipeline Node</span></div>
 <div><img src="https://raw.githubusercontent.com/redhat-developer/vscode-tekton/master/images/task.png" width="15" height="15" /><span style="margin: 20px">Task Node</span></div>
 <div><img src="https://raw.githubusercontent.com/redhat-developer/vscode-tekton/master/images/clustertask.png" width="15" height="15" /><span style="margin: 20px">ClusterTask Node</span></div>
-<div><img src="https://raw.githubusercontent.com/redhat-developer/vscode-tekton/master/images/pipe.png" width="15" height="15" /><span style="margin: 20px">PipelineResource Node</span></div
+<div><img src="https://raw.githubusercontent.com/redhat-developer/vscode-tekton/master/images/pipe.png" width="15" height="15" /><span style="margin: 20px">PipelineResource Node</span></div>
 <div><img src="https://raw.githubusercontent.com/redhat-developer/vscode-tekton/master/images/running.png" width="15" height="15" /><span style="margin: 20px">PipelineRun/TaskRun Running</span></div>
 <div><img src="https://raw.githubusercontent.com/redhat-developer/vscode-tekton/master/images/success.png" width="15" height="15" /><span style="margin: 20px">PipelineRun/TaskRun Successful Run</span></div>
 <div><img src="https://raw.githubusercontent.com/redhat-developer/vscode-tekton/master/images/failed.png" width="15" height="15" /><span style="margin: 20px">PipelineRun/TaskRun Failed Run</span></div>


### PR DESCRIPTION
Updated broken link for [tekton.png](https://github.com/redhat-developer/vscode-tekton/blob/master/images/tekton.png).

Also closed div tag for PipelineRun/TaskRun in README.