### PR TITLE
Remove code that updates package.json extensionDependencies attribute

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,6 @@ node('rhel7'){
 
     stage ("Package vscode-tekton") {
         def packageJson = readJSON file: 'package.json'
-        packageJson.extensionDependencies = ["ms-kubernetes-tools.vscode-kubernetes-tools"]
-        writeJSON file: 'package.json', json: packageJson, pretty: 4
         sh "vsce package -o tekton-pipelines-${packageJson.version}-${env.BUILD_NUMBER}.vsix"
     }
 


### PR DESCRIPTION
This code is not required, because kubernetes extension is already
listed as a dependency.