### PR TITLE
Use current namespace/project form kubeconfig everywhere

### DIFF
--- a/src/tekton/clustertask.ts
+++ b/src/tekton/clustertask.ts
@@ -13,7 +13,7 @@ export class ClusterTask extends TektonItem {
     }
 
     static async list(clustertasks: TektonNode): Promise<void> {
-            if (clustertasks) { ClusterTask.tkn.executeInTerminal(Command.listClusterTasksinTerminal("default")); }
+            if (clustertasks) { ClusterTask.tkn.executeInTerminal(Command.listClusterTasksinTerminal()); }
     }
 
     static async delete(clustertask: TektonNode): Promise<void> {

--- a/src/tekton/task.ts
+++ b/src/tekton/task.ts
@@ -15,7 +15,7 @@ export class Task extends TektonItem {
     static async list(task: TektonNode): Promise<void> {
 /*         const task = await Task.getTektonCmdData(treeItem,
             "Which task do you want to list"); */
-        if (task) { Task.tkn.executeInTerminal(Command.listTasksinTerminal("default")); }
+        if (task) { Task.tkn.executeInTerminal(Command.listTasksinTerminal()); }
     }
 
     static async delete(task: TektonNode): Promise<void> {

--- a/src/tekton/taskrun.ts
+++ b/src/tekton/taskrun.ts
@@ -9,7 +9,7 @@ import { TektonNode, Command } from '../tkn';
 export class TaskRun extends TektonItem {
 
     static async list(taskrun: TektonNode): Promise<void> {
-        if (taskrun) { TaskRun.tkn.executeInTerminal(Command.listTaskRunsInTerminal("default")); }
+        if (taskrun) { TaskRun.tkn.executeInTerminal(Command.listTaskRunsInTerminal()); }
     }
 
     static async listFromTask(taskrun: TektonNode): Promise<void> {

--- a/test/tekton/clustertask.test.ts
+++ b/test/tekton/clustertask.test.ts
@@ -47,7 +47,7 @@ suite('Tekton/Clustertask', () => {
 
             test('executes the list tkn command in terminal', async () => {
                 await ClusterTask.list(clustertaskItem);
-                expect(termStub).calledOnceWith(Command.listClusterTasksinTerminal("default"));
+                expect(termStub).calledOnceWith(Command.listClusterTasksinTerminal());
             });
 
         });

--- a/test/tekton/task.test.ts
+++ b/test/tekton/task.test.ts
@@ -47,7 +47,7 @@ suite('Tekton/Task', () => {
 
         test('executes the list tkn command in terminal', async () => {
             await Task.list(taskItem);
-            expect(termStub).calledOnceWith(Command.listTasksinTerminal("default"));
+            expect(termStub).calledOnceWith(Command.listTasksinTerminal());
         });
 
     });

--- a/test/tekton/taskrun.test.ts
+++ b/test/tekton/taskrun.test.ts
@@ -47,7 +47,7 @@ suite('Tekton/TaskRun', () => {
 
             test('executes the list tkn command in terminal', async () => {
                 await TaskRun.list(taskrunItem);
-                expect(termStub).calledOnceWith(Command.listTaskRunsInTerminal("default"));
+                expect(termStub).calledOnceWith(Command.listTaskRunsInTerminal());
             });
 
         });


### PR DESCRIPTION
Fix #61.