### PR TITLE
Remove Clusters View form Explorer views container

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,10 +223,6 @@
     "views": {
       "explorer": [
         {
-          "id": "extension.vsKubernetesExplorer",
-          "name": "Clusters"
-        },
-        {
           "id": "tektonPipelineExplorer",
           "name": "Tekton Pipelines"
         }


### PR DESCRIPTION
Clusters view cannot be shown anywhere except in original Kubernetes views
container declared in Kubernetes extension form Microsoft.

Signed-off-by: Denis Golovin <dgolovin@redhat.com>