### PR TITLE
Limit number of pipelineruns and taskruns in a tree

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,7 @@
 			"type": "extensionHost",
 			"request": "launch",
 			"runtimeExecutable": "${execPath}",
+			"sourceMaps": true,
 			"args": [
 				"--extensionDevelopmentPath=${workspaceFolder}"
 			],

--- a/package.json
+++ b/package.json
@@ -537,19 +537,25 @@
           "vs-tekton.tkn-path": "",
           "vs-tekton.tknVersioning": "user-provided",
           "vs-kubernetes.outputFormat": "yaml"
+        },
+        "vs-tekton.showChannelOutput": {
+          "title": "Show channel on output",
+          "type": "boolean",
+          "default": "false",
+          "description": "Show Tekton Pipeline output channel when new text added to output stream"
+        },
+        "vs-tekton.outputVerbosityLevel": {
+          "title": "Output Verbosity Level",
+          "type": "number",
+          "default": 0,
+          "description": "Output verbosity level (value between 0 and 9) for Tekton Pipeline Start, Push and Watch commands in output channel and integrated terminal."
+        },
+        "vs-tekton.treePaginationLimit": {
+          "title": "Tree items pagination limit",
+          "type": "number",
+          "default": 5,
+          "description": "Tree pagination limit for some tekton related nodes(pipeline runs/task runs)"
         }
-      },
-      "vs-tekton.showChannelOutput": {
-        "title": "Show channel on output",
-        "type": "boolean",
-        "default": "false",
-        "description": "Show Tekton Pipeline output channel when new text added to output stream"
-      },
-      "vs-tekton.outputVerbosityLevel": {
-        "title": "Output Verbosity Level",
-        "type": "number",
-        "default": 0,
-        "description": "Output verbosity level (value between 0 and 9) for Tekton Pipeline Start, Push and Watch commands in output channel and integrated terminal."
       }
     }
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,7 @@ import fsx = require('fs-extra');
 import * as k8s from 'vscode-kubernetes-tools-api';
 import { ClusterTask } from './tekton/clustertask';
 import { PipelineResource } from './tekton/pipelineresource';
+import { TektonNode } from './tkn';
 
 export let contextGlobalState: vscode.ExtensionContext;
 let tektonExplorer: k8s.ClusterExplorerV1 | undefined = undefined;
@@ -59,6 +60,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         // vscode.commands.registerCommand('tekton.taskrun.cancel', (context) => execute(TaskRun.cancel, context)),
         vscode.commands.registerCommand('tekton.taskrun.delete', (context) => execute(TaskRun.delete, context)),
         vscode.commands.registerCommand('tekton.explorer.reportIssue', () => PipelineExplorer.reportIssue()),
+        vscode.commands.registerCommand('_tekton.explorer.more', expandMoreItem),
         PipelineExplorer.getInstance()
     ];
     disposables.forEach((e) => context.subscriptions.push(e));
@@ -130,4 +132,9 @@ function migrateFromTkn018(): void {
         fsx.ensureDirSync(newCfgDir);
         fsx.copyFileSync(oldCfg, newCfg);
     }
+}
+
+function expandMoreItem(context: number, parent: TektonNode): void {
+        parent.visibleChildren += context;
+        PipelineExplorer.getInstance().refresh(parent);
 }

--- a/src/tkn.ts
+++ b/src/tkn.ts
@@ -545,12 +545,6 @@ function compareNodes(a, b): number {
     return t ? t : a.label.localeCompare(b.label);
 }
 
-function compareTime(a, b): number {
-    const aTime = Date.parse(a.creationTime);
-    const bTime = Date.parse(b.creationTime);
-    return aTime < bTime ? -1 : 1;
-}
-
 function compareTimeNewestFirst(a: TektonNode, b: TektonNode): number {
     const aTime = Date.parse(a.creationTime);
     const bTime = Date.parse(b.creationTime);

--- a/src/tkn.ts
+++ b/src/tkn.ts
@@ -4,7 +4,7 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { CliCommand, CliExitData, Cli, CliImpl, createCliCommand, cliCommandToString } from './cli';
-import { ProviderResult, TreeItemCollapsibleState, Terminal, Uri, QuickPickItem, workspace } from 'vscode';
+import { ProviderResult, TreeItemCollapsibleState, Terminal, Uri, QuickPickItem, workspace, Command as vsCommand, TreeItem } from 'vscode';
 import { WindowUtil } from './util/windowUtils';
 import * as path from 'path';
 import { ToolsConfig } from './tools';
@@ -41,6 +41,7 @@ export interface TektonNode extends QuickPickItem {
     contextValue: string;
     creationTime?: string;
     state?: string;
+    visibleChildren?: number;
     getChildren(): ProviderResult<TektonNode[]>;
     getParent(): TektonNode;
     getName(): string;
@@ -478,6 +479,45 @@ export class PipelineRun extends TektonNodeImpl {
     }
 }
 
+export class MoreNode extends TreeItem implements TektonNode {
+    contextValue: string;
+    creationTime?: string;
+    state?: string;
+    detail?: string;
+    picked?: boolean;
+    alwaysShow?: boolean;
+    label: string;
+
+    constructor(private showNext: number,
+        private totalCount: number,
+        private parent: TektonNode) {
+        super(`more`, TreeItemCollapsibleState.None);
+    }
+
+    get command(): vsCommand {
+        return { command: '_tekton.explorer.more', title: `more ${this.showNext}`, arguments: [this.showNext, this.parent, this] };
+    }
+
+    get tooltip(): string {
+        return `${this.showNext} more from ${this.totalCount}`
+    }
+
+    get description(): string {
+        return `${this.showNext} from ${this.totalCount}`
+    }
+
+    getChildren(): ProviderResult<TektonNode[]> {
+        throw new Error("Method not implemented.");
+    }
+    getParent(): TektonNode {
+        return this.parent;
+    }
+    getName(): string {
+        return this.label;
+    }
+
+}
+
 export interface Tkn {
     getPipelineNodes(): Promise<TektonNode[]>;
     startPipeline(pipeline: StartPipelineObject): Promise<TektonNode[]>;
@@ -511,16 +551,24 @@ function compareTime(a, b): number {
     return aTime < bTime ? -1 : 1;
 }
 
+function compareTimeNewestFirst(a: TektonNode, b: TektonNode): number {
+    const aTime = Date.parse(a.creationTime);
+    const bTime = Date.parse(b.creationTime);
+    return aTime < bTime ? 1 : -1;
+}
+
 export class TknImpl implements Tkn {
 
     public static ROOT: TektonNode = new TektonNodeImpl(undefined, 'root', undefined, undefined);
     private cache: Map<TektonNode, TektonNode[]> = new Map();
     private static cli: Cli = CliImpl.getInstance();
     private static instance: Tkn;
+    // Get page size from configuration, in case configuration is not present(dev mode) use hard coded value
+    defaultPageSize: number = workspace.getConfiguration('vs-tekton').has('treePaginationLimit') ? workspace.getConfiguration('vs-tekton').get('treePaginationLimit') : 5;
 
     // eslint-disable-next-line @typescript-eslint/no-empty-function
-    private constructor() { 
-        
+    private constructor() {
+
     }
 
     public static get Instance(): Tkn {
@@ -564,12 +612,24 @@ export class TknImpl implements Tkn {
     }
 
     async getPipelineRuns(pipeline: TektonNode): Promise<TektonNode[]> {
+        if (!pipeline.visibleChildren) {
+            pipeline.visibleChildren = this.defaultPageSize;
+        }
         let pipelineRuns: TektonNode[] = this.cache.get(pipeline);
         if (!pipelineRuns) {
             pipelineRuns = await this._getPipelineRuns(pipeline);
             this.cache.set(pipeline, pipelineRuns);
         }
-        return pipelineRuns;
+
+        const currentRuns = pipelineRuns.slice(0, Math.min(pipeline.visibleChildren, pipelineRuns.length))
+        if (pipeline.visibleChildren < pipelineRuns.length) {
+            let nextPage = this.defaultPageSize;
+            if (pipeline.visibleChildren + this.defaultPageSize > pipelineRuns.length) {
+                nextPage = pipelineRuns.length - pipeline.visibleChildren;
+            }
+            currentRuns.push(new MoreNode(nextPage, pipelineRuns.length, pipeline));
+        }
+        return currentRuns;
     }
 
     async _getPipelineRuns(pipeline: TektonNode): Promise<TektonNode[]> | undefined {
@@ -583,14 +643,14 @@ export class TknImpl implements Tkn {
         try {
             const r = JSON.parse(result.stdout);
             data = r.items ? r.items : data;
-        // eslint-disable-next-line no-empty
+            // eslint-disable-next-line no-empty
         } catch (ignore) {
         }
 
         return data
             .filter((value) => value.spec.pipelineRef.name === pipeline.getName())
             .map((value) => new PipelineRun(pipeline, value.metadata.name, this, value))
-            .sort(compareTime);
+            .sort(compareTimeNewestFirst);
     }
 
     public async getTaskRunsforTasks(task: TektonNode): Promise<TektonNode[]> {
@@ -611,22 +671,35 @@ export class TknImpl implements Tkn {
         let data: PipelineTaskRunData[] = [];
         try {
             data = JSON.parse(result.stdout).items;
-        // eslint-disable-next-line no-empty
+            // eslint-disable-next-line no-empty
         } catch (ignore) {
         }
         return data
             .filter((value) => value.spec.taskRef.name === task.getName())
             .map((value) => new TaskRun(task, value.metadata.name, this, value))
-            .sort(compareTime);
+            .sort(compareTimeNewestFirst);
     }
 
     async getTaskRuns(pipelineRun: TektonNode): Promise<TektonNode[]> {
+        if (!pipelineRun.visibleChildren) {
+            pipelineRun.visibleChildren = this.defaultPageSize;
+        }
+
         let taskRuns: TektonNode[] = this.cache.get(pipelineRun);
         if (!taskRuns) {
             taskRuns = await this._getTaskRuns(pipelineRun);
             this.cache.set(pipelineRun, taskRuns);
         }
-        return taskRuns;
+
+        const currentRuns = taskRuns.slice(0, Math.min(pipelineRun.visibleChildren, taskRuns.length))
+        if (pipelineRun.visibleChildren < taskRuns.length) {
+            let nextPage = this.defaultPageSize;
+            if (pipelineRun.visibleChildren + this.defaultPageSize > taskRuns.length) {
+                nextPage = taskRuns.length - pipelineRun.visibleChildren;
+            }
+            currentRuns.push(new MoreNode(nextPage, taskRuns.length, pipelineRun));
+        }
+        return currentRuns;
     }
 
     async _getTaskRuns(pipelinerun: TektonNode): Promise<TektonNode[]> {
@@ -638,14 +711,14 @@ export class TknImpl implements Tkn {
         let data: PipelineTaskRunData[] = [];
         try {
             data = JSON.parse(result.stdout).items;
-        // eslint-disable-next-line no-empty
+            // eslint-disable-next-line no-empty
         } catch (ignore) {
         }
 
         return data
             .filter((value) => value.metadata.labels["tekton.dev/pipelineRun"] === pipelinerun.getName())
             .map((value) => new TaskRun(pipelinerun, value.metadata.name, this, value))
-            .sort(compareTime);
+            .sort(compareTimeNewestFirst);
     }
 
     async getPipelines(pipeline: TektonNode): Promise<TektonNode[]> {
@@ -703,7 +776,7 @@ export class TknImpl implements Tkn {
         }
         try {
             data = JSON.parse(result.stdout).items;
-        // eslint-disable-next-line no-empty
+            // eslint-disable-next-line no-empty
         } catch (ignore) {
         }
         let tasks: string[] = data.map((value) => value.metadata.name);
@@ -720,7 +793,7 @@ export class TknImpl implements Tkn {
         try {
             const result = await this.execute(Command.listClusterTasks());
             data = JSON.parse(result.stdout).items;
-        // eslint-disable-next-line no-empty
+            // eslint-disable-next-line no-empty
         } catch (ignore) {
 
         }
@@ -734,7 +807,7 @@ export class TknImpl implements Tkn {
         let data: TknTask[] = [];
         try {
             data = JSON.parse(result.stdout).items;
-        // eslint-disable-next-line no-empty
+            // eslint-disable-next-line no-empty
         } catch (ignore) {
 
         }

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -135,4 +135,11 @@ suite("Tekton Pipeline Extension", async () => {
         await vscode.commands.executeCommand("tekton.explorer.refresh");
         expect(semStub).calledWith(error);
     });
+
+    test('more command should call refresh on parent item', async () => {
+        const refreshStub = sandbox.stub(PipelineExplorer.prototype, 'refresh'); 
+        const parentItem = sandbox.mock(pipelineItem);
+        await vscode.commands.executeCommand('_tekton.explorer.more', 42, parentItem);
+        expect(refreshStub).calledWith(parentItem);
+    });
 });

--- a/test/tkn.test.ts
+++ b/test/tkn.test.ts
@@ -4,6 +4,7 @@
  *-----------------------------------------------------------------------------------------------*/
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import * as tkn from '../src/tkn';
 import { CliImpl, createCliCommand } from '../src/cli';
 import * as sinon from 'sinon';

--- a/test/tkn.test.ts
+++ b/test/tkn.test.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
- /* eslint-disable @typescript-eslint/no-unused-vars */
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import * as tkn from '../src/tkn';
 import { CliImpl, createCliCommand } from '../src/cli';
 import * as sinon from 'sinon';
@@ -18,6 +18,7 @@ import jsYaml = require('js-yaml');
 import { TestItem } from './tekton/testTektonitem';
 import { ExecException } from 'child_process';
 import * as path from 'path';
+import { TektonNode } from '../src/tkn';
 
 const expect = chai.expect;
 chai.use(sinonChai);
@@ -373,6 +374,198 @@ suite("tkn", () => {
             expect(result).empty;
         });
 
+        test('getPipelineRuns returns list sorted newest first', async () => {
+            const tknPipelinesRuns = ['pipelinerun2', 'pipelinerun1'];
+            execStub.resolves({
+                error: null, stderr: '',
+                stdout: JSON.stringify({
+                    items: [
+                        {
+                            "kind": "PipelineRun",
+                            "apiVersion": "tekton.dev/v1alpha1",
+                            "metadata": {
+                                "name": "pipelinerun1"
+                            },
+                            "spec": {
+                                "pipelineRef": {
+                                    "name": "pipeline1"
+                                }
+                            },
+                            "status": {
+                                "conditions": [
+                                    {
+                                        "status": "True",
+                                    }
+                                ],
+                                "startTime": "2019-07-25T12:03:00Z",
+                                "taskRuns": {
+                                }
+                            }
+                        },
+                        {
+                            "kind": "PipelineRun",
+                            "apiVersion": "tekton.dev/v1alpha1",
+                            "metadata": {
+                                "name": "pipelinerun2"
+                            },
+                            "spec": {
+                                "pipelineRef": {
+                                    "name": "pipeline1"
+                                }
+                            },
+                            "status": {
+                                "conditions": [
+                                    {
+                                        "status": "True",
+                                    }
+                                ],
+                                "startTime": "2019-07-25T12:03:11Z",
+                                "taskRuns": {
+                                }
+                            }
+                        }]
+                })
+            });
+
+            const result = await tknCli.getPipelineRuns(pipelineItem1);
+            expect(result.length).equals(2);
+            for (let i = 0; i < result.length; i++) {
+                expect(result[i].getName()).equals(tknPipelinesRuns[i]);
+            }
+        });
+
+        test('getPipelineRuns returns "more" item', async () => {
+            const tknPipelinesRuns = ['pipelinerun2', 'more'];
+            sandbox.replace(tknCli as any, "defaultPageSize", 1);
+            const pipelineItem1 = new TestItem(pipelineNodeItem, 'pipeline1', tkn.ContextType.PIPELINE);
+
+
+
+            execStub.resolves({
+                error: null, stderr: '',
+                stdout: JSON.stringify({
+                    items: [
+                        {
+                            "kind": "PipelineRun",
+                            "apiVersion": "tekton.dev/v1alpha1",
+                            "metadata": {
+                                "name": "pipelinerun1"
+                            },
+                            "spec": {
+                                "pipelineRef": {
+                                    "name": "pipeline1"
+                                }
+                            },
+                            "status": {
+                                "conditions": [
+                                    {
+                                        "status": "True",
+                                    }
+                                ],
+                                "startTime": "2019-07-25T12:03:00Z",
+                                "taskRuns": {
+                                }
+                            }
+                        },
+                        {
+                            "kind": "PipelineRun",
+                            "apiVersion": "tekton.dev/v1alpha1",
+                            "metadata": {
+                                "name": "pipelinerun2"
+                            },
+                            "spec": {
+                                "pipelineRef": {
+                                    "name": "pipeline1"
+                                }
+                            },
+                            "status": {
+                                "conditions": [
+                                    {
+                                        "status": "True",
+                                    }
+                                ],
+                                "startTime": "2019-07-25T12:03:11Z",
+                                "taskRuns": {
+                                }
+                            }
+                        }]
+                })
+            });
+
+
+
+            const result = await tknCli.getPipelineRuns(pipelineItem1);
+            expect(result.length).equals(2);
+            for (let i = 0; i < result.length; i++) {
+                expect(result[i].getName()).equals(tknPipelinesRuns[i]);
+            }
+        });
+
+        test('getPipelineRuns set visible item default', async () => {
+            const tknPipelinesRuns = ['pipelinerun2', 'more'];
+            sandbox.replace(tknCli as any, "defaultPageSize", 42);
+            const pipelineItem1 = new TestItem(pipelineNodeItem, 'pipeline1', tkn.ContextType.PIPELINE);
+
+
+
+            execStub.resolves({
+                error: null, stderr: '',
+                stdout: JSON.stringify({
+                    items: [
+                        {
+                            "kind": "PipelineRun",
+                            "apiVersion": "tekton.dev/v1alpha1",
+                            "metadata": {
+                                "name": "pipelinerun1"
+                            },
+                            "spec": {
+                                "pipelineRef": {
+                                    "name": "pipeline1"
+                                }
+                            },
+                            "status": {
+                                "conditions": [
+                                    {
+                                        "status": "True",
+                                    }
+                                ],
+                                "startTime": "2019-07-25T12:03:00Z",
+                                "taskRuns": {
+                                }
+                            }
+                        },
+                        {
+                            "kind": "PipelineRun",
+                            "apiVersion": "tekton.dev/v1alpha1",
+                            "metadata": {
+                                "name": "pipelinerun2"
+                            },
+                            "spec": {
+                                "pipelineRef": {
+                                    "name": "pipeline1"
+                                }
+                            },
+                            "status": {
+                                "conditions": [
+                                    {
+                                        "status": "True",
+                                    }
+                                ],
+                                "startTime": "2019-07-25T12:03:11Z",
+                                "taskRuns": {
+                                }
+                            }
+                        }]
+                })
+            });
+
+
+
+            const result = await tknCli.getPipelineRuns(pipelineItem1);
+            expect(result.length).equals(2);
+            expect((pipelineItem1 as TektonNode).visibleChildren).to.equals(42);
+        });
+
         test('getTaskRun returns taskrun list for a pipelinerun', async () => {
             execStub.resolves({
                 error: null, stderr: '', stdout: JSON.stringify({
@@ -429,11 +622,11 @@ suite("tkn", () => {
             const result = await tknCli.getTaskRuns(pipelinerunItem);
 
             expect(result.length).equals(2);
-            expect(result[0].getName()).equals('taskrun2');
+            expect(result[0].getName()).equals('taskrun1');
         });
 
         test('getTaskruns returns taskruns for a pipelinerun', async () => {
-            const tknTaskRuns = ['taskrun2', 'taskrun1'];
+            const tknTaskRuns = ['taskrun1', 'taskrun2'];
             execStub.resolves({
                 error: null, stderr: '', stdout: JSON.stringify({
                     "items": [
@@ -560,11 +753,11 @@ suite("tkn", () => {
             const result = await tknCli.getTaskRunsforTasks(taskItem);
 
             expect(result.length).equals(2);
-            expect(result[0].getName()).equals('taskrun2');
+            expect(result[0].getName()).equals('taskrun1');
         });
 
         test('getTaskrunsFromTasks returns taskruns for a task', async () => {
-            const tknTaskRuns = ['taskrun2', 'taskrun1'];
+            const tknTaskRuns = ['taskrun1', 'taskrun2'];
             execStub.resolves({
                 error: null, stderr: '', stdout: JSON.stringify({
                     "items": [
@@ -693,11 +886,11 @@ suite("tkn", () => {
             const result = await tknCli.getTaskRunsforTasks(clustertaskItem);
 
             expect(result.length).equals(2);
-            expect(result[0].getName()).equals('taskrun2');
+            expect(result[0].getName()).equals('taskrun1');
         });
 
         test('getTaskrunsFromTasks returns taskruns for a clustertask', async () => {
-            const tknTaskRuns = ['taskrun2', 'taskrun1'];
+            const tknTaskRuns = ['taskrun1', 'taskrun2'];
             execStub.resolves({
                 error: null, stderr: '', stdout: JSON.stringify({
                     "items": [
@@ -804,6 +997,33 @@ suite("tkn", () => {
             execStub.onFirstCall().resolves({ error: undefined, stdout: '', stderr: 'error: the server doesn\'t have a resource type "pipeline"' });
             const result = await tknCli.getPipelineNodes();
             assert.equal(result[0].getName(), "Please install the OpenShift Pipelines Operator.");
+        });
+    });
+
+    suite('mode node', () => {
+        const pipelineNodeItem = new TestItem(tkn.TknImpl.ROOT, 'pipelinenode', tkn.ContextType.PIPELINENODE);
+        const pipelineItem = new TestItem(pipelineNodeItem, 'pipeline1', tkn.ContextType.PIPELINE);
+
+        test('more node has command', () => {
+            const more = new tkn.MoreNode(4, 10, pipelineItem);
+            const moreCommand = more.command;
+            assert.equal(moreCommand.command, '_tekton.explorer.more');
+        });
+
+        test('more node has command arguments', () => {
+            const more = new tkn.MoreNode(4, 10, pipelineItem);
+            const moreCommand = more.command;
+            assert.deepEqual(moreCommand.arguments, [4, pipelineItem, more]);
+        });
+
+        test('more node has name', () => {
+            const more = new tkn.MoreNode(4, 10, pipelineItem);
+            assert.equal(more.getName(), 'more');
+        });
+
+        test('more node has description', () => {
+            const more = new tkn.MoreNode(4, 10, pipelineItem);
+            assert.equal(more.description, '4 from 10');
         });
     });
 });


### PR DESCRIPTION
This PR add limit on number of tree item for `pipelineruns` and `taskruns`, by default limit is `5` but can be changed in a preferences(`treePaginationLimit` option)

Also this PR changes the way how `pipelineruns` and `taskruns` are sorted and listed in a tree.
Now all of them sorted by creation time and newest showing first.

Demo:
![ezgif com-resize](https://user-images.githubusercontent.com/929743/72260394-6bdec580-361b-11ea-80e6-c15c256e52b4.gif)
  

Fix for: #79