### PR TITLE
Basic editing support for pipeline yaml

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -199,7 +199,8 @@
     "@types/pluralize": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.29.tgz",
-      "integrity": "sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA=="
+      "integrity": "sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==",
+      "dev": true
     },
     "@types/request": {
       "version": "2.48.3",
@@ -210,6 +211,15 @@
         "@types/node": "*",
         "@types/tough-cookie": "*",
         "form-data": "^2.5.0"
+      }
+    },
+    "@types/semver": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.1.0.tgz",
+      "integrity": "sha512-pOKLaubrAEMUItGNpgwl0HMFPrSAFic8oSVIvfu1UwcgGNmNyK9gyhBHKmBnUTwwVvpZfkzUC0GaMgnL6P86uA==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "@types/shelljs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,7 +198,7 @@
     },
     "@types/pluralize": {
       "version": "0.0.29",
-      "resolved": "http://localhost:8080/@types/pluralize/-/pluralize-0.0.29.tgz",
+      "resolved": "https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.29.tgz",
       "integrity": "sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA=="
     },
     "@types/request": {
@@ -2324,7 +2324,7 @@
     },
     "lodash": {
       "version": "4.17.15",
-      "resolved": "http://localhost:8080/lodash/-/lodash-4.17.15.tgz",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash.unescape": {
@@ -2691,6 +2691,11 @@
         "node-forge": "^0.8.1",
         "uuid": "^3.3.2"
       }
+    },
+    "node-yaml-parser": {
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/node-yaml-parser/-/node-yaml-parser-0.0.9.tgz",
+      "integrity": "sha512-bFFmAdUs9sdD+TwF/A91b4ozU2KJSDuK7HiBV0QDhdG7Cunu/4PakBLn3wWWAJurAJd7GqAeEwYhu32bTHOvQg=="
     },
     "nopt": {
       "version": "3.0.6",

--- a/package.json
+++ b/package.json
@@ -606,7 +606,9 @@
     "@types/mkdirp": "^0.5.2",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.0.10",
+    "@types/pluralize": "^0.0.29",
     "@types/request": "^2.48.1",
+    "@types/semver": "^7.1.0",
     "@types/shelljs": "^0.8.5",
     "@types/sinon": "^5.0.7",
     "@types/sinon-chai": "^3.2.2",
@@ -637,7 +639,6 @@
   },
   "dependencies": {
     "@kubernetes/client-node": "^0.10.2",
-    "@types/pluralize": "^0.0.29",
     "binary-search": "^1.3.5",
     "byline": "^5.0.0",
     "event-stream": "3.3.4",

--- a/package.json
+++ b/package.json
@@ -560,7 +560,8 @@
     }
   },
   "extensionDependencies": [
-    "ms-kubernetes-tools.vscode-kubernetes-tools"
+    "ms-kubernetes-tools.vscode-kubernetes-tools",
+    "redhat.vscode-yaml"
   ],
   "scripts": {
     "verify": "node ./out/build/verify-tools.js",
@@ -626,7 +627,9 @@
     "hasha": "5.0.0",
     "humanize-duration": "^3.21.0",
     "js-yaml": "^3.13.1",
+    "lodash": "^4.17.15",
     "mkdirp": "^0.5.1",
+    "node-yaml-parser": "0.0.9",
     "open": "^6.4.0",
     "pluralize": "^4.0.0",
     "request": "^2.88.0",

--- a/scheme/pipeline.json
+++ b/scheme/pipeline.json
@@ -1,0 +1,298 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "additionalProperties": true,
+    "type": "object",
+    "required": [
+        "apiVersion",
+        "kind",
+        "spec",
+        "metadata"
+    ],
+    "properties": {
+        "apiVersion": {
+            "type": "string",
+            "enum": [
+                "tekton.dev/v1alpha1"
+            ],
+            "default": "tekton.dev/v1alpha1"
+        },
+        "kind": {
+            "type": "string",
+            "enum": [
+                "Pipeline"
+            ]
+        },
+        "metadata": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$ref": "#/definitions/ObjectMeta"
+        },
+        "spec": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$ref": "#/definitions/PipelineSpec"
+        }
+    },
+    "definitions": {
+        "ArrayOrString": {
+            "type": [
+                "string",
+                "array"
+            ],
+            "items": {
+                "type": "string"
+            }
+        },
+        "ObjectMeta": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": true,
+            "required": [
+                "name"
+            ],
+            "type": "object"
+        },
+        "Param": {
+            "required": [
+                "name",
+                "value"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {
+                    "$ref": "#/definitions/ArrayOrString"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "ParamSpec": {
+            "required": [
+                "name"
+            ],
+            "properties": {
+                "default": {
+                    "$ref": "#/definitions/ArrayOrString"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "PipelineConditionResource": {
+            "required": [
+                "name",
+                "resource"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "resource": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "PipelineDeclaredResource": {
+            "required": [
+                "name",
+                "type"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "PipelineSpec": {
+            "properties": {
+                "params": {
+                    "items": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "$ref": "#/definitions/ParamSpec"
+                    },
+                    "type": "array"
+                },
+                "resources": {
+                    "items": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "$ref": "#/definitions/PipelineDeclaredResource"
+                    },
+                    "type": "array"
+                },
+                "tasks": {
+                    "items": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "$ref": "#/definitions/PipelineTask"
+                    },
+                    "type": "array"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "PipelineTask": {
+            "required": [
+                "taskRef"
+            ],
+            "properties": {
+                "conditions": {
+                    "items": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "$ref": "#/definitions/PipelineTaskCondition"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "params": {
+                    "items": {
+                        "$ref": "#/definitions/Param"
+                    },
+                    "type": "array"
+                },
+                "resources": {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "$ref": "#/definitions/PipelineTaskResources"
+                },
+                "retries": {
+                    "type": "integer"
+                },
+                "runAfter": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "taskRef": {
+                    "$schema": "http://json-schema.org/draft-07/schema#",
+                    "$ref": "#/definitions/TaskRef"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "PipelineTaskCondition": {
+            "required": [
+                "conditionRef"
+            ],
+            "properties": {
+                "conditionRef": {
+                    "type": "string"
+                },
+                "params": {
+                    "items": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "$ref": "#/definitions/Param"
+                    },
+                    "type": "array"
+                },
+                "resources": {
+                    "items": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "$ref": "#/definitions/PipelineConditionResource"
+                    },
+                    "type": "array"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "PipelineTaskInputResource": {
+            "required": [
+                "name",
+                "resource"
+            ],
+            "properties": {
+                "from": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "resource": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "PipelineTaskOutputResource": {
+            "required": [
+                "name",
+                "resource"
+            ],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "resource": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "PipelineTaskResources": {
+            "properties": {
+                "inputs": {
+                    "items": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "$ref": "#/definitions/PipelineTaskInputResource"
+                    },
+                    "type": "array"
+                },
+                "outputs": {
+                    "items": {
+                        "$schema": "http://json-schema.org/draft-07/schema#",
+                        "$ref": "#/definitions/PipelineTaskOutputResource"
+                    },
+                    "type": "array"
+                }
+            },
+            "additionalProperties": false,
+            "type": "object"
+        },
+        "TaskRef": {
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "kind": {
+                    "type": "string",
+                    "enum": [
+                        "Task",
+                        "ClusterTask"
+                    ]
+                }
+            },
+            "additionalProperties": false,
+            "type": "object",
+            "required": [
+                "name"
+            ]
+        }
+    }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,6 +16,7 @@ import * as k8s from 'vscode-kubernetes-tools-api';
 import { ClusterTask } from './tekton/clustertask';
 import { PipelineResource } from './tekton/pipelineresource';
 import { TektonNode } from './tkn';
+import { registerYamlSchemaSupport } from './yaml-support/tkn-yaml-schema';
 
 export let contextGlobalState: vscode.ExtensionContext;
 let tektonExplorer: k8s.ClusterExplorerV1 | undefined = undefined;
@@ -83,6 +84,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     } else {
         vscode.window.showErrorMessage('Command not available: ${tektonExplorer.reason}');
     }
+
+    registerYamlSchemaSupport(context);
 }
 
 async function isTekton(): Promise<boolean> {
@@ -135,6 +138,6 @@ function migrateFromTkn018(): void {
 }
 
 function expandMoreItem(context: number, parent: TektonNode): void {
-        parent.visibleChildren += context;
-        PipelineExplorer.getInstance().refresh(parent);
+    parent.visibleChildren += context;
+    PipelineExplorer.getInstance().refresh(parent);
 }

--- a/src/tekton.d.ts
+++ b/src/tekton.d.ts
@@ -33,8 +33,34 @@ export interface TknSpec {
 }
 
 export interface TknTaskSpec {
-    inputs: {};
+    inputs?: TknInputs;
+    outputs?: TknOutputs;
     steps: [];
+}
+
+export interface ParamSpec {
+    name: string;
+    type?: string;
+    description?: string;
+    default?: string | string[];
+}
+
+export interface TknInputs {
+    resources?: TaskResource[];
+    params?: ParamSpec[];
+}
+
+export interface TknOutputs {
+    results?: {};
+    resources?: TaskResource[];
+}
+
+export interface TaskResource {
+    name: string;
+    type: string;
+    description?: string;
+    targetPath?: string;
+    optional?: boolean;
 }
 
 
@@ -49,6 +75,7 @@ export interface TknPipelineResource {
 }
 
 export interface TknTask {
+    kind: string;
     metadata: TknMetadata;
     spec: TknTaskSpec;
 }

--- a/src/tekton.d.ts
+++ b/src/tekton.d.ts
@@ -7,10 +7,10 @@
 
 export interface TknMetadata {
     name: string;
-    generation: number;
-    namespace: string;
-    uid: string;
-    resourceVersion: string;
+    generation?: number;
+    namespace?: string;
+    uid?: string;
+    resourceVersion?: string;
 }
 
 export interface TknParams {
@@ -35,7 +35,7 @@ export interface TknSpec {
 export interface TknTaskSpec {
     inputs?: TknInputs;
     outputs?: TknOutputs;
-    steps: [];
+    steps: Array;
 }
 
 export interface ParamSpec {

--- a/src/tkn.ts
+++ b/src/tkn.ts
@@ -236,7 +236,7 @@ export class Command {
     }
 
     static tknStatus(): CliCommand {
-        return newOcCommand('auth', 'can-i', 'create', 'pipeline.tekton.dev', '&&', 'oc', 'get', 'pipeline.tekton.dev' );
+        return newOcCommand('auth', 'can-i', 'create', 'pipeline.tekton.dev', '&&', 'oc', 'get', 'pipeline.tekton.dev');
     }
 
 }
@@ -526,8 +526,10 @@ export interface Tkn {
     getPipelineRuns(pipelineRun: TektonNode): Promise<TektonNode[]>;
     getPipelineResources(pipelineResources: TektonNode): Promise<TektonNode[]>;
     getTasks(task: TektonNode): Promise<TektonNode[]>;
+    getRawTasks(): Promise<TknTask[]>;
     getTaskRuns(taskRun: TektonNode): Promise<TektonNode[]>;
     getClusterTasks(clustertask: TektonNode): Promise<TektonNode[]>;
+    getRawClusterTasks(): Promise<TknTask[]>;
     execute(command: CliCommand, cwd?: string, fail?: boolean): Promise<CliExitData>;
     executeInTerminal(command: CliCommand, cwd?: string): void;
     getTaskRunsforTasks(task: TektonNode): Promise<TektonNode[]>;
@@ -778,6 +780,22 @@ export class TknImpl implements Tkn {
         return tasks.map<TektonNode>((value) => new TektonNodeImpl(task, value, ContextType.TASK, this, TreeItemCollapsibleState.Collapsed)).sort(compareNodes);
     }
 
+    async getRawTasks(): Promise<TknTask[]> {
+        let data: TknTask[] = [];
+        const result = await this.execute(Command.listTasks());
+        if (result.stderr) {
+            console.log(result + "Std.err when processing tasks");
+            return data;
+        }
+        try {
+            data = JSON.parse(result.stdout).items;
+            // eslint-disable-next-line no-empty
+        } catch (ignore) {
+        }
+
+        return data;
+    }
+
     async getClusterTasks(clustertask: TektonNode): Promise<TektonNode[]> {
         return (await this._getClusterTasks(clustertask));
     }
@@ -794,6 +812,22 @@ export class TknImpl implements Tkn {
         let tasks: string[] = data.map((value) => value.metadata.name);
         tasks = [...new Set(tasks)];
         return tasks.map<TektonNode>((value) => new TektonNodeImpl(clustertask, value, ContextType.CLUSTERTASK, this, TreeItemCollapsibleState.Collapsed)).sort(compareNodes);
+    }
+
+    async getRawClusterTasks(): Promise<TknTask[]> {
+        let data: TknTask[] = [];
+        const result = await this.execute(Command.listClusterTasks());
+        if (result.stderr) {
+            console.log(result + "Std.err when processing tasks");
+            return data;
+        }
+        try {
+            data = JSON.parse(result.stdout).items;
+            // eslint-disable-next-line no-empty
+        } catch (ignore) {
+        }
+
+        return data;
     }
 
     async startPipeline(pipeline: StartPipelineObject): Promise<TektonNode[]> {

--- a/src/tkn.ts
+++ b/src/tkn.ts
@@ -792,7 +792,7 @@ export class TknImpl implements Tkn {
     async getRawTasks(): Promise<TknTask[]> {
         let data: TknTask[] = [];
         const result = await this.execute(Command.listTasks());
-        if (result.stderr) {
+        if (result.error) {
             console.log(result + "Std.err when processing tasks");
             return data;
         }
@@ -826,7 +826,7 @@ export class TknImpl implements Tkn {
     async getRawClusterTasks(): Promise<TknTask[]> {
         let data: TknTask[] = [];
         const result = await this.execute(Command.listClusterTasks());
-        if (result.stderr) {
+        if (result.error) {
             console.log(result + "Std.err when processing tasks");
             return data;
         }

--- a/src/yaml-support/tkn-scheme-storage.ts
+++ b/src/yaml-support/tkn-scheme-storage.ts
@@ -1,0 +1,41 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+import * as vscode from 'vscode';
+
+interface TknSchemeCacheItem {
+    scheme: string;
+    version: number;
+}
+
+export interface SchemeGenerator {
+    (vsDocument: vscode.TextDocument): Promise<string>;
+}
+
+export class TknSchemeStorage {
+
+    private cache: { [key: string]: TknSchemeCacheItem } = {};
+
+    async getScheme(vsDocument: vscode.TextDocument, generator: SchemeGenerator): Promise<string> {
+        const key = vsDocument.uri.toString();
+        await this.ensureCache(key, vsDocument, generator);
+        return this.cache[key].scheme;
+    }
+
+    private async ensureCache(key: string, doc: vscode.TextDocument, generator: SchemeGenerator): Promise<void> {
+        if (!this.cache[key]) {
+            this.cache[key] = { version: -1 } as TknSchemeCacheItem;
+        }
+
+        if (this.cache[key].version !== doc.version) {
+            const scheme = await generator(doc);
+            this.cache[key].scheme = scheme;
+            this.cache[key].version = doc.version;
+        }
+    }
+}
+
+const schemeStorage = new TknSchemeStorage();
+
+export { schemeStorage };

--- a/src/yaml-support/tkn-tasks-provider.ts
+++ b/src/yaml-support/tkn-tasks-provider.ts
@@ -92,7 +92,7 @@ function convertTaskToSnippet(task: TknTask): TaskSnippet {
         result.taskRef.kind = task.kind;
 
     }
-    if (task.spec.inputs || task.spec.outputs) {
+    if (task.spec.inputs?.resources || task.spec.outputs?.resources) {
         result.resources = {};
     }
 
@@ -100,15 +100,16 @@ function convertTaskToSnippet(task: TknTask): TaskSnippet {
         const params: Param[] = [];
         for (const rawParam of task.spec.inputs.params) {
             if (rawParam.default) {
-                continue
+                continue;
             }
             params.push({
                 name: rawParam.name,
                 value: '$' + placeHolder++
             });
         }
-
-        result.params = params;
+        if (params.length > 0) {
+            result.params = params;
+        }
     }
 
     if (task.spec.inputs) {

--- a/src/yaml-support/tkn-tasks-provider.ts
+++ b/src/yaml-support/tkn-tasks-provider.ts
@@ -1,0 +1,145 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+import { TknImpl } from "../tkn";
+import { TknTask } from "../tekton";
+
+export interface Snippet {
+    label: string;
+    description?: string;
+    body: TaskSnippet;
+}
+
+interface TaskSnippet {
+    name: string;
+    taskRef: TaskRef;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    taskSpec?: any; // TODO check this
+    conditions?: PipelineTaskCondition[];
+    retries?: number;
+    runAfter?: string[];
+    resources?: PipelineTaskResources;
+    params?: Param[];
+
+}
+
+interface PipelineTaskCondition {
+    conditionRef: string;
+    params?: Param[];
+    resources: PipelineTaskInputResource[];
+}
+
+interface PipelineTaskResources {
+    inputs?: PipelineTaskInputResource[];
+    outputs?: PipelineTaskOutputResource[];
+}
+
+interface PipelineTaskInputResource {
+    name: string;
+    resource: string;
+    from?: string[];
+}
+
+interface PipelineTaskOutputResource {
+    name: string;
+    resource: string;
+}
+
+interface TaskRef {
+    name: string;
+    kind?: 'Task' | 'ClusterTask';
+}
+
+interface Param {
+    name: string;
+    value: string | string[];
+}
+
+export async function getTknTasksSnippets(): Promise<Snippet[]> {
+    const tkn = TknImpl.Instance;
+    const [rawClusterTasks, rawTasks] = await Promise.all([tkn.getRawClusterTasks(), tkn.getRawTasks()]);
+
+    const allRawTasks = rawClusterTasks.concat(rawTasks);
+
+    const snippets = convertTasksToSnippet(allRawTasks);
+    return snippets;
+}
+
+export function convertTasksToSnippet(rawTasks: TknTask[]): Snippet[] {
+    const result: Snippet[] = [];
+
+    for (const task of rawTasks) {
+        result.push({
+            label: task.metadata.name,
+            description: task.kind,
+            body: convertTaskToSnippet(task)
+        })
+    }
+    return result;
+}
+
+function convertTaskToSnippet(task: TknTask): TaskSnippet {
+    let placeHolder = 1;
+    const result: TaskSnippet = {
+        name: '$' + placeHolder++,
+        taskRef: {
+            name: task.metadata.name
+        }
+    };
+
+    if (task.kind === 'ClusterTask') {
+        result.taskRef.kind = task.kind;
+
+    }
+    if (task.spec.inputs || task.spec.outputs) {
+        result.resources = {};
+    }
+
+    if (task.spec.inputs?.params) {
+        const params: Param[] = [];
+        for (const rawParam of task.spec.inputs.params) {
+            if (rawParam.default) {
+                continue
+            }
+            params.push({
+                name: rawParam.name,
+                value: '$' + placeHolder++
+            });
+        }
+
+        result.params = params;
+    }
+
+    if (task.spec.inputs) {
+        const rawInputs = task.spec.inputs;
+        if (rawInputs.resources) {
+            const inputs: PipelineTaskInputResource[] = [];
+            for (const rawInput of rawInputs.resources) {
+                inputs.push({
+                    name: rawInput.name,
+                    resource: '$' + placeHolder++,
+                });
+            }
+            result.resources.inputs = inputs;
+        }
+
+    }
+
+    if (task.spec.outputs?.resources) {
+        const rawOutputs = task.spec.outputs;
+        const outputs: PipelineTaskOutputResource[] = [];
+        for (const rawOutput of rawOutputs.resources) {
+            outputs.push({
+                name: rawOutput.name,
+                resource: '$' + placeHolder++,
+            });
+        }
+
+        result.resources.outputs = outputs;
+    }
+
+
+    return result;
+
+}

--- a/src/yaml-support/tkn-tasks-provider.ts
+++ b/src/yaml-support/tkn-tasks-provider.ts
@@ -99,12 +99,9 @@ function convertTaskToSnippet(task: TknTask): TaskSnippet {
     if (task.spec.inputs?.params) {
         const params: Param[] = [];
         for (const rawParam of task.spec.inputs.params) {
-            if (rawParam.default) {
-                continue;
-            }
             params.push({
                 name: rawParam.name,
-                value: '$' + placeHolder++
+                value: rawParam.default ? rawParam.default : '$' + placeHolder++
             });
         }
         if (params.length > 0) {

--- a/src/yaml-support/tkn-yaml-schema.ts
+++ b/src/yaml-support/tkn-yaml-schema.ts
@@ -17,6 +17,7 @@ interface SchemaAdditions {
     action: MODIFICATION_ACTIONS.add;
     path: string;
     key: string;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     content: any;
 }
 
@@ -71,7 +72,9 @@ export async function registerYamlSchemaSupport(context: vscode.ExtensionContext
 
     //TODO: remove this!!!
 
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const rcs = (yamlPlugin as any).requestCustomSchema.bind(yamlPlugin);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (yamlPlugin as any).requestCustomSchema = async (resource: string): Promise<string[]> => {
         const result: string[] = await rcs(resource);
         if (result.includes('kubernetes://schema/tekton.dev/v1alpha1@pipeline')) {

--- a/src/yaml-support/tkn-yaml-schema.ts
+++ b/src/yaml-support/tkn-yaml-schema.ts
@@ -45,32 +45,8 @@ export async function registerYamlSchemaSupport(context: vscode.ExtensionContext
     }
 
     yamlPlugin.registerContributor('tekton', requestYamlSchemaUriCallback, requestYamlSchemaContentCallback);
-    // vscode.window.onDidChangeActiveTextEditor(async e => {
-    //     // filter non yaml files
-    //     if (e?.document.languageId !== 'yaml') {
-    //         return;
-    //     }
-    //     // const tknYamlType = isTektonYaml(e.document);
-    //     // if (tknYamlType && tknYamlType === TektonYamlType.Pipeline) {
 
-    //     // }
-    //     try {
-    //         // const snippets = await getTknTasksSnippets();
-    //         // await yamlPlugin.modifySchemaContent({
-    //         //     action: MODIFICATION_ACTIONS.add,
-    //         //     schema: "kubernetes://schema/tekton.dev/v1alpha1@pipeline",
-    //         //     key: "defaultSnippets",
-    //         //     path: "spec/tasks",
-    //         //     content: snippets
-    //         // });
-
-
-    //     } catch (e) {
-    //         console.error(e);
-    //     }
-    // });
-
-    //TODO: remove this!!!
+    //TODO: This is temporary, until 'vscode-yaml' not fixed 'modifySchemaContent' for contributed schema
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const rcs = (yamlPlugin as any).requestCustomSchema.bind(yamlPlugin);
@@ -105,7 +81,7 @@ async function activateYamlExtension(): Promise<YamlExtensionAPI | undefined> {
         vscode.window.showWarningMessage('The installed Red Hat YAML extension doesn\'t support in memory schemas modification. Please upgrade \'YAML Support by Red Hat\' via the Extensions pane.');
         return undefined;
     }
-    if (ext.packageJSON.version && !semver.gte(ext.packageJSON.version, '0.7.1')) {
+    if (ext.packageJSON.version && !semver.gte(ext.packageJSON.version, '0.7.2')) {
         vscode.window.showWarningMessage('The installed Red Hat YAML extension doesn\'t support schemas modification. Please upgrade \'YAML Support by Red Hat\' via the Extensions pane.');
     }
     return yamlPlugin;

--- a/src/yaml-support/tkn-yaml-schema.ts
+++ b/src/yaml-support/tkn-yaml-schema.ts
@@ -1,0 +1,151 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+import * as vscode from 'vscode';
+import * as semver from 'semver';
+import { isTektonYaml, TektonYamlType } from './tkn-yaml';
+import { generateScheme } from './tkn-yaml-scheme-generator';
+
+enum MODIFICATION_ACTIONS {
+    'delete',
+    'add'
+}
+
+interface SchemaAdditions {
+    schema: string;
+    action: MODIFICATION_ACTIONS.add;
+    path: string;
+    key: string;
+    content: any;
+}
+
+interface SchemaDeletions {
+    schema: string;
+    action: MODIFICATION_ACTIONS.delete;
+    path: string;
+    key: string;
+}
+
+interface YamlExtensionAPI {
+    registerContributor(schema: string, requestSchema: (resource: string) => string, requestSchemaContent: (uri: string) => Promise<string>): boolean;
+    modifySchemaContent(schemaModifications: SchemaAdditions | SchemaDeletions): Promise<void>;
+}
+const VSCODE_YAML_EXTENSION_ID = 'redhat.vscode-yaml';
+let extContext: vscode.ExtensionContext;
+const tektonUriCache = new Map<string, string>();
+
+export async function registerYamlSchemaSupport(context: vscode.ExtensionContext): Promise<void> {
+    extContext = context;
+    const yamlPlugin = await activateYamlExtension();
+    if (!yamlPlugin || !yamlPlugin.modifySchemaContent) {
+        // activateYamlExtension has already alerted to users for errors.
+        return;
+    }
+
+    yamlPlugin.registerContributor('tekton', requestYamlSchemaUriCallback, requestYamlSchemaContentCallback);
+    // vscode.window.onDidChangeActiveTextEditor(async e => {
+    //     // filter non yaml files
+    //     if (e?.document.languageId !== 'yaml') {
+    //         return;
+    //     }
+    //     // const tknYamlType = isTektonYaml(e.document);
+    //     // if (tknYamlType && tknYamlType === TektonYamlType.Pipeline) {
+
+    //     // }
+    //     try {
+    //         // const snippets = await getTknTasksSnippets();
+    //         // await yamlPlugin.modifySchemaContent({
+    //         //     action: MODIFICATION_ACTIONS.add,
+    //         //     schema: "kubernetes://schema/tekton.dev/v1alpha1@pipeline",
+    //         //     key: "defaultSnippets",
+    //         //     path: "spec/tasks",
+    //         //     content: snippets
+    //         // });
+
+
+    //     } catch (e) {
+    //         console.error(e);
+    //     }
+    // });
+
+    //TODO: remove this!!!
+
+    const rcs = (yamlPlugin as any).requestCustomSchema.bind(yamlPlugin);
+    (yamlPlugin as any).requestCustomSchema = async (resource: string): Promise<string[]> => {
+        const result: string[] = await rcs(resource);
+        if (result.includes('kubernetes://schema/tekton.dev/v1alpha1@pipeline')) {
+            const index = result.indexOf('kubernetes://schema/tekton.dev/v1alpha1@pipeline');
+            if (index > -1) {
+                result.splice(index, 1);
+            }
+        }
+
+        return result;
+    }
+}
+
+async function activateYamlExtension(): Promise<YamlExtensionAPI | undefined> {
+    const ext = vscode.extensions.getExtension(VSCODE_YAML_EXTENSION_ID);
+    if (!ext) {
+        vscode.window.showWarningMessage('Please install \'YAML Support by Red Hat\' via the Extensions pane.');
+        return undefined;
+    }
+    const yamlPlugin = await ext.activate();
+
+    if (!yamlPlugin || !yamlPlugin.registerContributor) {
+        vscode.window.showWarningMessage('The installed Red Hat YAML extension doesn\'t support Kubernetes Intellisense. Please upgrade \'YAML Support by Red Hat\' via the Extensions pane.');
+        return undefined;
+    }
+
+    if (!yamlPlugin || !yamlPlugin.modifySchemaContent) {
+        vscode.window.showWarningMessage('The installed Red Hat YAML extension doesn\'t support in memory schemas modification. Please upgrade \'YAML Support by Red Hat\' via the Extensions pane.');
+        return undefined;
+    }
+    if (ext.packageJSON.version && !semver.gte(ext.packageJSON.version, '0.7.1')) {
+        vscode.window.showWarningMessage('The installed Red Hat YAML extension doesn\'t support schemas modification. Please upgrade \'YAML Support by Red Hat\' via the Extensions pane.');
+    }
+    return yamlPlugin;
+}
+
+function requestYamlSchemaUriCallback(resource: string): string | undefined {
+    const textEditor = vscode.window.visibleTextEditors.find((editor) => editor.document.uri.toString() === resource);
+    if (textEditor) {
+        const tektonYamlType = isTektonYaml(textEditor.document);
+        if (tektonYamlType && tektonYamlType === TektonYamlType.Pipeline) {
+            let resourceUrl = vscode.Uri.parse(resource);
+            resourceUrl = resourceUrl.with({ scheme: 'tekton' });
+            tektonUriCache.set(resourceUrl.toString(), textEditor.document.uri.toString());
+            return resourceUrl.toString();
+        }
+    }
+
+    return undefined;
+}
+
+async function requestYamlSchemaContentCallback(uri: string): Promise<string> {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    try {
+        const doc = getDocument(uri);
+        if (doc) {
+            return generateScheme(extContext, doc);
+        }
+
+    } catch (err) {
+        console.error(err);
+    }
+
+    return undefined;
+
+}
+
+function getDocument(tektonUri: string): vscode.TextDocument | undefined {
+    if (tektonUriCache.has(tektonUri)) {
+        const resource = tektonUriCache.get(tektonUri);
+        const textEditor = vscode.window.visibleTextEditors.find((editor) => editor.document.uri.toString() === resource);
+        if (textEditor) {
+            return textEditor.document;
+        }
+    }
+}
+

--- a/src/yaml-support/tkn-yaml-scheme-generator.ts
+++ b/src/yaml-support/tkn-yaml-scheme-generator.ts
@@ -17,11 +17,13 @@ export function generateScheme(extContext: vscode.ExtensionContext, vsDocument: 
 }
 
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function injectTaskSnippets(templateObj: any, snippets: Snippet[]): {} {
     templateObj.definitions.PipelineSpec.properties.tasks.defaultSnippets = snippets;
     return templateObj;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function injectTasksName(templateObj: any, tasks: string[], tasksRef: string[]): {} {
     templateObj.definitions.PipelineTask.properties.runAfter.items.enum = tasks;
 
@@ -33,6 +35,7 @@ function injectTasksName(templateObj: any, tasks: string[], tasksRef: string[]):
     return templateObj;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function injectResourceName(templateObj: any, resNames: string[]): {} {
     if (resNames && resNames.length > 0) {
         templateObj.definitions.PipelineTaskInputResource.properties.resource.enum = resNames;

--- a/src/yaml-support/tkn-yaml-scheme-generator.ts
+++ b/src/yaml-support/tkn-yaml-scheme-generator.ts
@@ -1,0 +1,58 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { readFile } from 'fs-extra'
+import { Snippet, getTknTasksSnippets } from './tkn-tasks-provider';
+import { schemeStorage } from './tkn-scheme-storage'
+import { getPipelineTasksName, getDeclaredResources } from './tkn-yaml';
+
+let context: vscode.ExtensionContext;
+export function generateScheme(extContext: vscode.ExtensionContext, vsDocument: vscode.TextDocument): Promise<string> {
+    context = extContext;
+
+    return schemeStorage.getScheme(vsDocument, generate);
+}
+
+
+function injectTaskSnippets(templateObj: any, snippets: Snippet[]): {} {
+    templateObj.definitions.PipelineSpec.properties.tasks.defaultSnippets = snippets;
+    return templateObj;
+}
+
+function injectTasksName(templateObj: any, tasks: string[], tasksRef: string[]): {} {
+    templateObj.definitions.PipelineTask.properties.runAfter.items.enum = tasks;
+
+    //inject names of all tasks deployed in cluster + namespace
+    if (tasksRef && tasksRef.length > 0) {
+        templateObj.definitions.TaskRef.properties.name.enum = tasksRef;
+    }
+
+    return templateObj;
+}
+
+function injectResourceName(templateObj: any, resNames: string[]): {} {
+    if (resNames && resNames.length > 0) {
+        templateObj.definitions.PipelineTaskInputResource.properties.resource.enum = resNames;
+        templateObj.definitions.PipelineTaskOutputResource.properties.resource.enum = resNames;
+    }
+    
+    return templateObj;
+}
+
+async function generate(doc: vscode.TextDocument): Promise<string> {
+    const template = await readFile(path.join(context.extensionPath, 'scheme', 'pipeline.json'), 'UTF8');
+    const snippets = await getTknTasksSnippets();
+    const definedTasks = getPipelineTasksName(doc);
+    const declaredResources = getDeclaredResources(doc);
+
+    const resNames = declaredResources.map(item => item.name);
+    const templateObj = JSON.parse(template);
+    let templateWithSnippets = injectTaskSnippets(templateObj, snippets);
+    const tasksRef = snippets.map(value => value.body.taskRef.name);
+    templateWithSnippets = injectTasksName(templateWithSnippets, definedTasks, tasksRef);
+    templateWithSnippets = injectResourceName(templateWithSnippets, resNames);
+    return JSON.stringify(templateWithSnippets);
+}

--- a/src/yaml-support/tkn-yaml.ts
+++ b/src/yaml-support/tkn-yaml.ts
@@ -1,0 +1,190 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+import * as vscode from 'vscode';
+import { yamlLocator, YamlMap, YamlSequence, YamlNode } from './yaml-locator';
+import * as _ from 'lodash';
+
+const TEKTON_API_VERSION = 'tekton.dev/v1alpha1';
+
+export enum TektonYamlType {
+    Task = 'Task',
+    TaskRun = 'TaskRun',
+    Pipeline = 'Pipeline',
+    PipelineRun = 'PipelineRun',
+    PipelineResource = 'PipelineResource'
+}
+
+export interface DeclaredResource {
+    name: string;
+    type: string;
+}
+
+export function isTektonYaml(vsDocument: vscode.TextDocument): TektonYamlType | undefined {
+    const yamlDocuments = yamlLocator.getYamlDocuments(vsDocument);
+    for (const doc of yamlDocuments) {
+        const rootMap = doc.nodes.find(node => node.kind === 'MAPPING') as YamlMap;
+        if (rootMap) {
+            const apiVersion = getYamlMappingValue(rootMap, 'apiVersion');
+            const kind = getYamlMappingValue(rootMap, 'kind');
+            if (apiVersion && apiVersion === TEKTON_API_VERSION) {
+                return TektonYamlType[kind];
+            }
+        }
+    }
+    return undefined;
+}
+
+export function getPipelineTasksRefName(vsDocument: vscode.TextDocument): string[] {
+    const result: string[] = [];
+    if (isTektonYaml(vsDocument) === TektonYamlType.Pipeline) {
+        const yamlDocuments = yamlLocator.getYamlDocuments(vsDocument);
+        for (const doc of yamlDocuments) {
+            const rootMap = doc.nodes.find(node => node.kind === 'MAPPING') as YamlMap;
+            if (rootMap) {
+                const specMap = getSpecMap(rootMap);
+                if (specMap) {
+                    const tasksSeq = getTasksSeq(specMap);
+                    if (tasksSeq) {
+                        result.push(...getTasksRefName(tasksSeq.items));
+                    }
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+export function getPipelineTasksName(vsDocument: vscode.TextDocument): string[] {
+    const result: string[] = [];
+    if (isTektonYaml(vsDocument) === TektonYamlType.Pipeline) {
+        const yamlDocuments = yamlLocator.getYamlDocuments(vsDocument);
+        for (const doc of yamlDocuments) {
+            const rootMap = doc.nodes.find(node => node.kind === 'MAPPING') as YamlMap;
+            if (rootMap) {
+                const specMap = getSpecMap(rootMap);
+                if (specMap) {
+                    const tasksSeq = getTasksSeq(specMap);
+                    if (tasksSeq) {
+                        result.push(...getTasksName(tasksSeq.items));
+                    }
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+export function getDeclaredResources(vsDocument: vscode.TextDocument): DeclaredResource[] {
+    const result: DeclaredResource[] = [];
+    if (isTektonYaml(vsDocument) === TektonYamlType.Pipeline) {
+        const yamlDocuments = yamlLocator.getYamlDocuments(vsDocument);
+        for (const doc of yamlDocuments) {
+            const rootMap = doc.nodes.find(node => node.kind === 'MAPPING') as YamlMap;
+            if (rootMap) {
+                const specMap = getSpecMap(rootMap);
+                if (specMap) {
+                    const resourcesSeq = findNodeByKey<YamlSequence>('resources', specMap);
+                    if (resourcesSeq) {
+                        for (const res of resourcesSeq.items) {
+                            if (res.kind === 'MAPPING') {
+                                result.push(getDeclaredResource(res as YamlMap));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+function getDeclaredResource(resMap: YamlMap): DeclaredResource {
+    let name: string, type: string;
+    for (const item of resMap.mappings) {
+        if (item.key.raw === 'name') {
+            name = item.value.raw;
+        }
+
+        if (item.key.raw === 'type') {
+            type = item.value.raw;
+        }
+    }
+
+    return { name, type };
+}
+
+function getSpecMap(rootMap: YamlMap): YamlMap | undefined {
+    return findNodeByKey<YamlMap>('spec', rootMap);
+}
+
+function getTasksSeq(specMap: YamlMap): YamlSequence | undefined {
+    return findNodeByKey<YamlSequence>('tasks', specMap);
+}
+
+function findNodeByKey<T>(key: string, yamlMap: YamlMap): T | undefined {
+    const mapItem = yamlMap.mappings.find(item => item.key.raw === key);
+    if (mapItem) {
+        return mapItem.value as unknown as T;
+    }
+
+    return undefined;
+}
+
+function getTasksRefName(tasks: YamlNode[]): string[] {
+    const result = [];
+    for (const taskNode of tasks) {
+        if (taskNode.kind === 'MAPPING') {
+            const taskRef = findNodeByKey<YamlMap>('taskRef', taskNode as YamlMap);
+            if (taskRef) {
+                const nameValue = findNodeByKey<YamlNode>('name', taskRef);
+                result.push(nameValue.raw);
+            }
+        }
+    }
+    return result;
+}
+
+function getTasksName(tasks: YamlNode[]): string[] {
+    const result = [];
+    for (const taskNode of tasks) {
+        if (taskNode.kind === 'MAPPING') {
+            const nameValue = findNodeByKey<YamlNode>('name', taskNode as YamlMap);
+            if (nameValue) {
+                result.push(nameValue.raw);
+            }
+        }
+    }
+    return result;
+}
+
+export enum StringComparison {
+    Ordinal,
+    OrdinalIgnoreCase
+}
+
+// test whether two strings are equal ignore case
+export function equalIgnoreCase(a: string, b: string): boolean {
+    return _.isString(a) && _.isString(b) && a.toLowerCase() === b.toLowerCase();
+}
+
+// Get the string value of key in a yaml mapping node(parsed by node-yaml-parser)
+// eg: on the following yaml, this method will return 'value1' for key 'key1'
+//
+//      key1: value1
+//      key2: value2
+//
+export function getYamlMappingValue(mapRootNode: YamlMap, key: string,
+    ignoreCase: StringComparison = StringComparison.Ordinal): string | undefined {
+    // TODO, unwrap quotes
+    if (!key) {
+        return undefined;
+    }
+    const keyValueItem = mapRootNode.mappings.find((mapping) => mapping.key &&
+        (ignoreCase === StringComparison.OrdinalIgnoreCase ? key === mapping.key.raw : equalIgnoreCase(key, mapping.key.raw)));
+    return keyValueItem ? keyValueItem.value.raw : undefined;
+}

--- a/src/yaml-support/yaml-locator.ts
+++ b/src/yaml-support/yaml-locator.ts
@@ -1,0 +1,125 @@
+/* eslint-disable header/header */
+// Copied from https://github.com/Azure/vscode-kubernetes-tools/blob/e16c0b239660585753dfed4732293737f6f5f06d/src/yaml-support/yaml-locator.ts
+
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+import { parse, findNodeAtPosition } from 'node-yaml-parser';
+
+export function isMapping(node: YamlNode): node is YamlMap {
+    return node.kind === 'MAPPING';
+}
+
+export function isSequence(node: YamlNode): node is YamlSequence {
+    return node.kind === 'SEQ';
+}
+
+export function isMappingItem(node: YamlNode): node is YamlMappingItem {
+    return node.kind === 'PAIR';
+}
+
+export interface YamlNode {
+    readonly kind: string;
+    readonly raw: string;
+    readonly startPosition: number;
+    readonly endPosition: number;
+    readonly parent?: YamlNode;
+}
+
+export interface YamlMappingItem extends YamlNode {
+    readonly key: YamlNode;
+    readonly value: YamlNode;
+}
+
+export interface YamlMap extends YamlNode {
+    readonly mappings: YamlMappingItem[];
+}
+
+export interface YamlSequence extends YamlNode {
+    readonly items: YamlNode[];
+}
+
+export interface YamlDocument {
+    readonly nodes: YamlNode[];
+    readonly errors: string[];
+}
+
+export interface YamlCachedDocuments {
+    // the documents represents the yaml text
+    yamlDocs: YamlDocument[];
+
+    // lineLengths contains the converted line length of each lines, it is used for converting from
+    // vscode position to the inner position in yaml element model.
+    lineLengths: number[];
+
+    // the version of the document to avoid duplicate work on the same text
+    version: number;
+}
+
+export interface YamlMatchedElement {
+    // the found node at the given position(usually at the edit/hover place)
+    readonly matchedNode: YamlNode;
+
+    // the document which contains the node at given position
+    readonly matchedDocument: YamlDocument;
+}
+
+/**
+ * A yaml interpreter parse the yaml text and find the matched ast node from vscode location.
+ */
+export class YamlLocator {
+    // a mapping of URIs to cached documents
+    private cache: { [key: string]: YamlCachedDocuments }  = {};
+
+    /**
+     * Parse the yaml text and find the best node&document for the given position.
+     *
+     * @param {vscode.TextDocument} textDocument vscode text document
+     * @param {vscode.Position} pos vscode position
+     * @returns {YamlMatchedElement} the search results of yaml elements at the given position
+     */
+    public getMatchedElement(textDocument: vscode.TextDocument, pos: vscode.Position): YamlMatchedElement {
+        const key: string = textDocument.uri.toString();
+        this.ensureCache(key, textDocument);
+        const cacheEntry = this.cache[key];
+        // findNodeAtPosition will find the matched node at given position
+        return findNodeAtPosition(cacheEntry.yamlDocs, cacheEntry.lineLengths, pos.line, pos.character);
+    }
+
+    /**
+     * Parse the yaml text and find the best node&document for the given position.
+     *
+     * @param {vscode.TextDocument} textDocument vscode text document
+     * @param {vscode.Position} pos vscode position
+     * @returns {YamlMatchedElement} the search results of yaml elements at the given position
+     */
+    public getYamlDocuments(textDocument: vscode.TextDocument): YamlDocument[] {
+        const key: string = textDocument.uri.toString();
+        this.ensureCache(key, textDocument);
+        return this.cache[key].yamlDocs;
+    }
+
+    private ensureCache(key: string, textDocument: vscode.TextDocument): void {
+        if (!this.cache[key]) {
+            this.cache[key] = { version: -1 } as YamlCachedDocuments;
+        }
+
+        if (this.cache[key].version !== textDocument.version) {
+            // the document and line lengths from parse method is cached into YamlCachedDocuments to avoid duplicate
+            // parse against the same text.
+            const { documents, lineLengths } = parse(textDocument.getText());
+            this.cache[key].yamlDocs = documents;
+            this.cache[key].lineLengths = lineLengths;
+            this.cache[key].version = textDocument.version;
+        }
+    }
+}
+
+// a global instance of yaml locator
+const yamlLocator = new YamlLocator();
+
+export { yamlLocator };

--- a/test/clustertask.json
+++ b/test/clustertask.json
@@ -1,0 +1,2303 @@
+[
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "buildah",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/buildah",
+            "uid": "439b5b24-c02e-4a10-8358-5ecf1cd5fed1",
+            "resourceVersion": "78656",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:53Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "resources": [
+                    {
+                        "name": "source",
+                        "type": "git"
+                    }
+                ],
+                "params": [
+                    {
+                        "name": "BUILDER_IMAGE",
+                        "type": "string",
+                        "description": "The location of the buildah builder image.",
+                        "default": "quay.io/buildah/stable:v1.11.0"
+                    },
+                    {
+                        "name": "DOCKERFILE",
+                        "type": "string",
+                        "description": "Path to the Dockerfile to build.",
+                        "default": "./Dockerfile"
+                    },
+                    {
+                        "name": "TLSVERIFY",
+                        "type": "string",
+                        "description": "Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)",
+                        "default": "true"
+                    }
+                ]
+            },
+            "outputs": {
+                "resources": [
+                    {
+                        "name": "image",
+                        "type": "image"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "build",
+                    "image": "$(inputs.params.BUILDER_IMAGE)",
+                    "command": [
+                        "buildah",
+                        "bud",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "--layers",
+                        "-f",
+                        "$(inputs.params.DOCKERFILE)",
+                        "-t",
+                        "$(outputs.resources.image.url)",
+                        "."
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                },
+                {
+                    "name": "push",
+                    "image": "$(inputs.params.BUILDER_IMAGE)",
+                    "command": [
+                        "buildah",
+                        "push",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "$(outputs.resources.image.url)",
+                        "docker://$(outputs.resources.image.url)"
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "varlibcontainers",
+                    "emptyDir": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "buildah-v0-8-0",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/buildah-v0-8-0",
+            "uid": "9b9b409f-d894-4805-9859-4c3842f72967",
+            "resourceVersion": "78657",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:53Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "resources": [
+                    {
+                        "name": "source",
+                        "type": "git"
+                    }
+                ],
+                "params": [
+                    {
+                        "name": "BUILDER_IMAGE",
+                        "type": "string",
+                        "description": "The location of the buildah builder image.",
+                        "default": "quay.io/buildah/stable:v1.11.0"
+                    },
+                    {
+                        "name": "DOCKERFILE",
+                        "type": "string",
+                        "description": "Path to the Dockerfile to build.",
+                        "default": "./Dockerfile"
+                    },
+                    {
+                        "name": "TLSVERIFY",
+                        "type": "string",
+                        "description": "Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)",
+                        "default": "true"
+                    }
+                ]
+            },
+            "outputs": {
+                "resources": [
+                    {
+                        "name": "image",
+                        "type": "image"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "build",
+                    "image": "$(inputs.params.BUILDER_IMAGE)",
+                    "command": [
+                        "buildah",
+                        "bud",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "--layers",
+                        "-f",
+                        "$(inputs.params.DOCKERFILE)",
+                        "-t",
+                        "$(outputs.resources.image.url)",
+                        "."
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                },
+                {
+                    "name": "push",
+                    "image": "$(inputs.params.BUILDER_IMAGE)",
+                    "command": [
+                        "buildah",
+                        "push",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "$(outputs.resources.image.url)",
+                        "docker://$(outputs.resources.image.url)"
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "varlibcontainers",
+                    "emptyDir": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "example-cluster-task",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/example-cluster-task",
+            "uid": "9f432731-5492-4169-b297-bee09dc2cdbf",
+            "resourceVersion": "320397",
+            "generation": 1,
+            "creationTimestamp": "2020-01-21T02:18:59Z"
+        },
+        "spec": {
+            "inputs": {
+                "params": [
+                    {
+                        "name": "appName",
+                        "type": "string"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "",
+                    "image": "registry.redhat.io/ubi7/ubi-minimal",
+                    "command": [
+                        "/bin/bash",
+                        "-c",
+                        "echo",
+                        "$(inputs.params.appName)"
+                    ],
+                    "resources": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "openshift-client",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/openshift-client",
+            "uid": "67f97279-bc47-4032-95ac-f21a210255f3",
+            "resourceVersion": "78662",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:53Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "params": [
+                    {
+                        "name": "ARGS",
+                        "type": "array",
+                        "description": "The OpenShift CLI arguments to run",
+                        "default": [
+                            "help"
+                        ]
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "oc",
+                    "image": "quay.io/openshift/origin-cli:latest",
+                    "command": [
+                        "/usr/bin/oc"
+                    ],
+                    "args": [
+                        "$(inputs.params.ARGS)"
+                    ],
+                    "resources": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "openshift-client-v0-8-0",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/openshift-client-v0-8-0",
+            "uid": "5417e8f7-d10c-464d-b7ba-f15c92ca1e9d",
+            "resourceVersion": "78666",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:54Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "params": [
+                    {
+                        "name": "ARGS",
+                        "type": "array",
+                        "description": "The OpenShift CLI arguments to run",
+                        "default": [
+                            "help"
+                        ]
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "oc",
+                    "image": "quay.io/openshift/origin-cli:latest",
+                    "command": [
+                        "/usr/bin/oc"
+                    ],
+                    "args": [
+                        "$(inputs.params.ARGS)"
+                    ],
+                    "resources": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "s2i",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/s2i",
+            "uid": "9bf60e52-d308-40f8-aa26-433588319811",
+            "resourceVersion": "78670",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:54Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "resources": [
+                    {
+                        "name": "source",
+                        "type": "git"
+                    }
+                ],
+                "params": [
+                    {
+                        "name": "BUILDER_IMAGE",
+                        "type": "string",
+                        "description": "The location of the s2i builder image."
+                    },
+                    {
+                        "name": "PATH_CONTEXT",
+                        "type": "string",
+                        "description": "The location of the path to run s2i from.",
+                        "default": "."
+                    },
+                    {
+                        "name": "TLSVERIFY",
+                        "type": "string",
+                        "description": "Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)",
+                        "default": "true"
+                    },
+                    {
+                        "name": "LOGLEVEL",
+                        "type": "string",
+                        "description": "Log level when running the S2I binary",
+                        "default": "0"
+                    }
+                ]
+            },
+            "outputs": {
+                "resources": [
+                    {
+                        "name": "image",
+                        "type": "image"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "generate",
+                    "image": "quay.io/openshift-pipeline/s2i:nightly",
+                    "command": [
+                        "/usr/local/bin/s2i",
+                        "--loglevel=$(inputs.params.LOGLEVEL)",
+                        "build",
+                        "$(inputs.params.PATH_CONTEXT)",
+                        "$(inputs.params.BUILDER_IMAGE)",
+                        "--as-dockerfile",
+                        "/gen-source/Dockerfile.gen"
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ]
+                },
+                {
+                    "name": "build",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "bud",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "--layers",
+                        "-f",
+                        "/gen-source/Dockerfile.gen",
+                        "-t",
+                        "$(outputs.resources.image.url)",
+                        "."
+                    ],
+                    "workingDir": "/gen-source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        },
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                },
+                {
+                    "name": "push",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "push",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "$(outputs.resources.image.url)",
+                        "docker://$(outputs.resources.image.url)"
+                    ],
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "varlibcontainers",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "gen-source",
+                    "emptyDir": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "s2i-go",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/s2i-go",
+            "uid": "5a9b36c5-55c1-4cfe-9806-7f3218531029",
+            "resourceVersion": "78675",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:55Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "resources": [
+                    {
+                        "name": "source",
+                        "type": "git"
+                    }
+                ],
+                "params": [
+                    {
+                        "name": "PATH_CONTEXT",
+                        "type": "string",
+                        "description": "The location of the path to run s2i from.",
+                        "default": "."
+                    },
+                    {
+                        "name": "TLSVERIFY",
+                        "type": "string",
+                        "description": "Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)",
+                        "default": "true"
+                    }
+                ]
+            },
+            "outputs": {
+                "resources": [
+                    {
+                        "name": "image",
+                        "type": "image"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "generate",
+                    "image": "quay.io/openshift-pipeline/s2i:v0.8.0",
+                    "command": [
+                        "s2i",
+                        "build",
+                        "$(inputs.params.PATH_CONTEXT)",
+                        "registry.access.redhat.com/devtools/go-toolset-rhel7",
+                        "--as-dockerfile",
+                        "/gen-source/Dockerfile.gen"
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ]
+                },
+                {
+                    "name": "build",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "bud",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "--layers",
+                        "-f",
+                        "/gen-source/Dockerfile.gen",
+                        "-t",
+                        "$(outputs.resources.image.url)",
+                        "."
+                    ],
+                    "workingDir": "/gen-source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        },
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                },
+                {
+                    "name": "push",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "push",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "$(outputs.resources.image.url)",
+                        "docker://$(outputs.resources.image.url)"
+                    ],
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "varlibcontainers",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "gen-source",
+                    "emptyDir": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "s2i-go-v0-8-0",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/s2i-go-v0-8-0",
+            "uid": "9b4324da-bdea-4427-8136-dfa48b8d6d0c",
+            "resourceVersion": "78678",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:55Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "resources": [
+                    {
+                        "name": "source",
+                        "type": "git"
+                    }
+                ],
+                "params": [
+                    {
+                        "name": "PATH_CONTEXT",
+                        "type": "string",
+                        "description": "The location of the path to run s2i from.",
+                        "default": "."
+                    },
+                    {
+                        "name": "TLSVERIFY",
+                        "type": "string",
+                        "description": "Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)",
+                        "default": "true"
+                    }
+                ]
+            },
+            "outputs": {
+                "resources": [
+                    {
+                        "name": "image",
+                        "type": "image"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "generate",
+                    "image": "quay.io/openshift-pipeline/s2i:v0.8.0",
+                    "command": [
+                        "s2i",
+                        "build",
+                        "$(inputs.params.PATH_CONTEXT)",
+                        "registry.access.redhat.com/devtools/go-toolset-rhel7",
+                        "--as-dockerfile",
+                        "/gen-source/Dockerfile.gen"
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ]
+                },
+                {
+                    "name": "build",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "bud",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "--layers",
+                        "-f",
+                        "/gen-source/Dockerfile.gen",
+                        "-t",
+                        "$(outputs.resources.image.url)",
+                        "."
+                    ],
+                    "workingDir": "/gen-source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        },
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                },
+                {
+                    "name": "push",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "push",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "$(outputs.resources.image.url)",
+                        "docker://$(outputs.resources.image.url)"
+                    ],
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "varlibcontainers",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "gen-source",
+                    "emptyDir": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "s2i-java-11",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/s2i-java-11",
+            "uid": "9bcb84b1-fc11-4cf3-8f69-02c9322f0e93",
+            "resourceVersion": "78680",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:56Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "resources": [
+                    {
+                        "name": "source",
+                        "type": "git"
+                    }
+                ],
+                "params": [
+                    {
+                        "name": "PATH_CONTEXT",
+                        "type": "string",
+                        "description": "The location of the path to run s2i from",
+                        "default": "."
+                    },
+                    {
+                        "name": "TLSVERIFY",
+                        "type": "string",
+                        "description": "Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)",
+                        "default": "true"
+                    },
+                    {
+                        "name": "MAVEN_ARGS_APPEND",
+                        "type": "string",
+                        "description": "Additional Maven arguments",
+                        "default": ""
+                    },
+                    {
+                        "name": "MAVEN_CLEAR_REPO",
+                        "type": "string",
+                        "description": "Remove the Maven repository after the artifact is built",
+                        "default": "false"
+                    },
+                    {
+                        "name": "MAVEN_MIRROR_URL",
+                        "type": "string",
+                        "description": "The base URL of a mirror used for retrieving artifacts",
+                        "default": ""
+                    }
+                ]
+            },
+            "outputs": {
+                "resources": [
+                    {
+                        "name": "image",
+                        "type": "image"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "gen-env-file",
+                    "image": "quay.io/openshift-pipeline/s2i:v0.8.0",
+                    "command": [
+                        "/bin/sh",
+                        "-c"
+                    ],
+                    "args": [
+                        "echo \"MAVEN_CLEAR_REPO=$(inputs.params.MAVEN_CLEAR_REPO)\" \u003e env-file\n\n[[ '$(inputs.params.MAVEN_ARGS_APPEND)' != \"\" ]] \u0026\u0026\n  echo \"MAVEN_ARGS_APPEND=$(inputs.params.MAVEN_ARGS_APPEND)\" \u003e\u003e env-file\n\n[[ '$(inputs.params.MAVEN_MIRROR_URL)' != \"\" ]] \u0026\u0026\n  echo \"MAVEN_MIRROR_URL=$(inputs.params.MAVEN_MIRROR_URL)\" \u003e\u003e env-file\n\necho \"Generated Env file\"\necho \"------------------------------\"\ncat env-file\necho \"------------------------------\""
+                    ],
+                    "workingDir": "/env-params",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "envparams",
+                            "mountPath": "/env-params"
+                        }
+                    ]
+                },
+                {
+                    "name": "generate",
+                    "image": "quay.io/openshift-pipeline/s2i",
+                    "command": [
+                        "s2i",
+                        "build",
+                        "$(inputs.params.PATH_CONTEXT)",
+                        "registry.access.redhat.com/openjdk/openjdk-11-rhel7",
+                        "--image-scripts-url",
+                        "image:///usr/local/s2i",
+                        "--as-dockerfile",
+                        "/gen-source/Dockerfile.gen",
+                        "--environment-file",
+                        "/env-params/env-file"
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        },
+                        {
+                            "name": "envparams",
+                            "mountPath": "/env-params"
+                        }
+                    ]
+                },
+                {
+                    "name": "build",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "bud",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "--layers",
+                        "-f",
+                        "/gen-source/Dockerfile.gen",
+                        "-t",
+                        "$(outputs.resources.image.url)",
+                        "."
+                    ],
+                    "workingDir": "/gen-source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        },
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                },
+                {
+                    "name": "push",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "push",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "$(outputs.resources.image.url)",
+                        "docker://$(outputs.resources.image.url)"
+                    ],
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "varlibcontainers",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "gen-source",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "envparams",
+                    "emptyDir": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "s2i-java-11-v0-8-0",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/s2i-java-11-v0-8-0",
+            "uid": "e65d1bbb-52a0-4c32-aa42-0105cc916faf",
+            "resourceVersion": "78682",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:56Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "resources": [
+                    {
+                        "name": "source",
+                        "type": "git"
+                    }
+                ],
+                "params": [
+                    {
+                        "name": "PATH_CONTEXT",
+                        "type": "string",
+                        "description": "The location of the path to run s2i from",
+                        "default": "."
+                    },
+                    {
+                        "name": "TLSVERIFY",
+                        "type": "string",
+                        "description": "Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)",
+                        "default": "true"
+                    },
+                    {
+                        "name": "MAVEN_ARGS_APPEND",
+                        "type": "string",
+                        "description": "Additional Maven arguments",
+                        "default": ""
+                    },
+                    {
+                        "name": "MAVEN_CLEAR_REPO",
+                        "type": "string",
+                        "description": "Remove the Maven repository after the artifact is built",
+                        "default": "false"
+                    },
+                    {
+                        "name": "MAVEN_MIRROR_URL",
+                        "type": "string",
+                        "description": "The base URL of a mirror used for retrieving artifacts",
+                        "default": ""
+                    }
+                ]
+            },
+            "outputs": {
+                "resources": [
+                    {
+                        "name": "image",
+                        "type": "image"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "gen-env-file",
+                    "image": "quay.io/openshift-pipeline/s2i:v0.8.0",
+                    "command": [
+                        "/bin/sh",
+                        "-c"
+                    ],
+                    "args": [
+                        "echo \"MAVEN_CLEAR_REPO=$(inputs.params.MAVEN_CLEAR_REPO)\" \u003e env-file\n\n[[ '$(inputs.params.MAVEN_ARGS_APPEND)' != \"\" ]] \u0026\u0026\n  echo \"MAVEN_ARGS_APPEND=$(inputs.params.MAVEN_ARGS_APPEND)\" \u003e\u003e env-file\n\n[[ '$(inputs.params.MAVEN_MIRROR_URL)' != \"\" ]] \u0026\u0026\n  echo \"MAVEN_MIRROR_URL=$(inputs.params.MAVEN_MIRROR_URL)\" \u003e\u003e env-file\n\necho \"Generated Env file\"\necho \"------------------------------\"\ncat env-file\necho \"------------------------------\""
+                    ],
+                    "workingDir": "/env-params",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "envparams",
+                            "mountPath": "/env-params"
+                        }
+                    ]
+                },
+                {
+                    "name": "generate",
+                    "image": "quay.io/openshift-pipeline/s2i",
+                    "command": [
+                        "s2i",
+                        "build",
+                        "$(inputs.params.PATH_CONTEXT)",
+                        "registry.access.redhat.com/openjdk/openjdk-11-rhel7",
+                        "--image-scripts-url",
+                        "image:///usr/local/s2i",
+                        "--as-dockerfile",
+                        "/gen-source/Dockerfile.gen",
+                        "--environment-file",
+                        "/env-params/env-file"
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        },
+                        {
+                            "name": "envparams",
+                            "mountPath": "/env-params"
+                        }
+                    ]
+                },
+                {
+                    "name": "build",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "bud",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "--layers",
+                        "-f",
+                        "/gen-source/Dockerfile.gen",
+                        "-t",
+                        "$(outputs.resources.image.url)",
+                        "."
+                    ],
+                    "workingDir": "/gen-source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        },
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                },
+                {
+                    "name": "push",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "push",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "$(outputs.resources.image.url)",
+                        "docker://$(outputs.resources.image.url)"
+                    ],
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "varlibcontainers",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "gen-source",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "envparams",
+                    "emptyDir": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "s2i-java-8",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/s2i-java-8",
+            "uid": "9c745856-a38d-453b-8baa-c23e2efba838",
+            "resourceVersion": "78683",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:56Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "resources": [
+                    {
+                        "name": "source",
+                        "type": "git"
+                    }
+                ],
+                "params": [
+                    {
+                        "name": "PATH_CONTEXT",
+                        "type": "string",
+                        "description": "The location of the path to run s2i from",
+                        "default": "."
+                    },
+                    {
+                        "name": "TLSVERIFY",
+                        "type": "string",
+                        "description": "Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)",
+                        "default": "true"
+                    },
+                    {
+                        "name": "MAVEN_ARGS_APPEND",
+                        "type": "string",
+                        "description": "Additional Maven arguments",
+                        "default": ""
+                    },
+                    {
+                        "name": "MAVEN_CLEAR_REPO",
+                        "type": "string",
+                        "description": "Remove the Maven repository after the artifact is built",
+                        "default": "false"
+                    },
+                    {
+                        "name": "MAVEN_MIRROR_URL",
+                        "type": "string",
+                        "description": "The base URL of a mirror used for retrieving artifacts",
+                        "default": ""
+                    }
+                ]
+            },
+            "outputs": {
+                "resources": [
+                    {
+                        "name": "image",
+                        "type": "image"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "gen-env-file",
+                    "image": "quay.io/openshift-pipeline/s2i:v0.8.0",
+                    "command": [
+                        "/bin/sh",
+                        "-c"
+                    ],
+                    "args": [
+                        "echo \"MAVEN_CLEAR_REPO=$(inputs.params.MAVEN_CLEAR_REPO)\" \u003e env-file\n\n[[ '$(inputs.params.MAVEN_ARGS_APPEND)' != \"\" ]] \u0026\u0026\n  echo \"MAVEN_ARGS_APPEND=$(inputs.params.MAVEN_ARGS_APPEND)\" \u003e\u003e env-file\n\n[[ '$(inputs.params.MAVEN_MIRROR_URL)' != \"\" ]] \u0026\u0026\n  echo \"MAVEN_MIRROR_URL=$(inputs.params.MAVEN_MIRROR_URL)\" \u003e\u003e env-file\n\necho \"Generated Env file\"\necho \"------------------------------\"\ncat env-file\necho \"------------------------------\""
+                    ],
+                    "workingDir": "/env-params",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "envparams",
+                            "mountPath": "/env-params"
+                        }
+                    ]
+                },
+                {
+                    "name": "generate",
+                    "image": "quay.io/openshift-pipeline/s2i",
+                    "command": [
+                        "s2i",
+                        "build",
+                        "$(inputs.params.PATH_CONTEXT)",
+                        "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift",
+                        "--image-scripts-url",
+                        "image:///usr/local/s2i",
+                        "--as-dockerfile",
+                        "/gen-source/Dockerfile.gen",
+                        "--environment-file",
+                        "/env-params/env-file"
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        },
+                        {
+                            "name": "envparams",
+                            "mountPath": "/env-params"
+                        }
+                    ]
+                },
+                {
+                    "name": "build",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "bud",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "--layers",
+                        "-f",
+                        "/gen-source/Dockerfile.gen",
+                        "-t",
+                        "$(outputs.resources.image.url)",
+                        "."
+                    ],
+                    "workingDir": "/gen-source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        },
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                },
+                {
+                    "name": "push",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "push",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "$(outputs.resources.image.url)",
+                        "docker://$(outputs.resources.image.url)"
+                    ],
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "varlibcontainers",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "gen-source",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "envparams",
+                    "emptyDir": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "s2i-java-8-v0-8-0",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/s2i-java-8-v0-8-0",
+            "uid": "ce0b4989-dcc9-429f-93b3-da9051a0c4e9",
+            "resourceVersion": "78687",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:57Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "resources": [
+                    {
+                        "name": "source",
+                        "type": "git"
+                    }
+                ],
+                "params": [
+                    {
+                        "name": "PATH_CONTEXT",
+                        "type": "string",
+                        "description": "The location of the path to run s2i from",
+                        "default": "."
+                    },
+                    {
+                        "name": "TLSVERIFY",
+                        "type": "string",
+                        "description": "Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)",
+                        "default": "true"
+                    },
+                    {
+                        "name": "MAVEN_ARGS_APPEND",
+                        "type": "string",
+                        "description": "Additional Maven arguments",
+                        "default": ""
+                    },
+                    {
+                        "name": "MAVEN_CLEAR_REPO",
+                        "type": "string",
+                        "description": "Remove the Maven repository after the artifact is built",
+                        "default": "false"
+                    },
+                    {
+                        "name": "MAVEN_MIRROR_URL",
+                        "type": "string",
+                        "description": "The base URL of a mirror used for retrieving artifacts",
+                        "default": ""
+                    }
+                ]
+            },
+            "outputs": {
+                "resources": [
+                    {
+                        "name": "image",
+                        "type": "image"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "gen-env-file",
+                    "image": "quay.io/openshift-pipeline/s2i:v0.8.0",
+                    "command": [
+                        "/bin/sh",
+                        "-c"
+                    ],
+                    "args": [
+                        "echo \"MAVEN_CLEAR_REPO=$(inputs.params.MAVEN_CLEAR_REPO)\" \u003e env-file\n\n[[ '$(inputs.params.MAVEN_ARGS_APPEND)' != \"\" ]] \u0026\u0026\n  echo \"MAVEN_ARGS_APPEND=$(inputs.params.MAVEN_ARGS_APPEND)\" \u003e\u003e env-file\n\n[[ '$(inputs.params.MAVEN_MIRROR_URL)' != \"\" ]] \u0026\u0026\n  echo \"MAVEN_MIRROR_URL=$(inputs.params.MAVEN_MIRROR_URL)\" \u003e\u003e env-file\n\necho \"Generated Env file\"\necho \"------------------------------\"\ncat env-file\necho \"------------------------------\""
+                    ],
+                    "workingDir": "/env-params",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "envparams",
+                            "mountPath": "/env-params"
+                        }
+                    ]
+                },
+                {
+                    "name": "generate",
+                    "image": "quay.io/openshift-pipeline/s2i",
+                    "command": [
+                        "s2i",
+                        "build",
+                        "$(inputs.params.PATH_CONTEXT)",
+                        "registry.access.redhat.com/redhat-openjdk-18/openjdk18-openshift",
+                        "--image-scripts-url",
+                        "image:///usr/local/s2i",
+                        "--as-dockerfile",
+                        "/gen-source/Dockerfile.gen",
+                        "--environment-file",
+                        "/env-params/env-file"
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        },
+                        {
+                            "name": "envparams",
+                            "mountPath": "/env-params"
+                        }
+                    ]
+                },
+                {
+                    "name": "build",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "bud",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "--layers",
+                        "-f",
+                        "/gen-source/Dockerfile.gen",
+                        "-t",
+                        "$(outputs.resources.image.url)",
+                        "."
+                    ],
+                    "workingDir": "/gen-source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        },
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                },
+                {
+                    "name": "push",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "push",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "$(outputs.resources.image.url)",
+                        "docker://$(outputs.resources.image.url)"
+                    ],
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "varlibcontainers",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "gen-source",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "envparams",
+                    "emptyDir": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "s2i-nodejs",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/s2i-nodejs",
+            "uid": "4f74140b-a7df-486b-9ac5-ffa363f3c31e",
+            "resourceVersion": "78689",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:57Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "resources": [
+                    {
+                        "name": "source",
+                        "type": "git"
+                    }
+                ],
+                "params": [
+                    {
+                        "name": "VERSION",
+                        "type": "string",
+                        "description": "The version of the nodejs",
+                        "default": "8"
+                    },
+                    {
+                        "name": "PATH_CONTEXT",
+                        "type": "string",
+                        "description": "The location of the path to run s2i from.",
+                        "default": "."
+                    },
+                    {
+                        "name": "TLSVERIFY",
+                        "type": "string",
+                        "description": "Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)",
+                        "default": "true"
+                    }
+                ]
+            },
+            "outputs": {
+                "resources": [
+                    {
+                        "name": "image",
+                        "type": "image"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "generate",
+                    "image": "quay.io/openshift-pipeline/s2i:v0.8.0",
+                    "command": [
+                        "s2i",
+                        "build",
+                        "$(inputs.params.PATH_CONTEXT)",
+                        "registry.access.redhat.com/rhscl/nodejs-$(inputs.params.VERSION)-rhel7",
+                        "--as-dockerfile",
+                        "/gen-source/Dockerfile.gen"
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ]
+                },
+                {
+                    "name": "build",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "bud",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "--layers",
+                        "-f",
+                        "/gen-source/Dockerfile.gen",
+                        "-t",
+                        "$(outputs.resources.image.url)",
+                        "."
+                    ],
+                    "workingDir": "/gen-source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        },
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                },
+                {
+                    "name": "push",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "push",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "$(outputs.resources.image.url)",
+                        "docker://$(outputs.resources.image.url)"
+                    ],
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "varlibcontainers",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "gen-source",
+                    "emptyDir": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "s2i-nodejs-v0-8-0",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/s2i-nodejs-v0-8-0",
+            "uid": "60cead5e-4acf-46e3-8334-859ab3a8530d",
+            "resourceVersion": "78693",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:58Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "resources": [
+                    {
+                        "name": "source",
+                        "type": "git"
+                    }
+                ],
+                "params": [
+                    {
+                        "name": "VERSION",
+                        "type": "string",
+                        "description": "The version of the nodejs",
+                        "default": "8"
+                    },
+                    {
+                        "name": "PATH_CONTEXT",
+                        "type": "string",
+                        "description": "The location of the path to run s2i from.",
+                        "default": "."
+                    },
+                    {
+                        "name": "TLSVERIFY",
+                        "type": "string",
+                        "description": "Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)",
+                        "default": "true"
+                    }
+                ]
+            },
+            "outputs": {
+                "resources": [
+                    {
+                        "name": "image",
+                        "type": "image"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "generate",
+                    "image": "quay.io/openshift-pipeline/s2i:v0.8.0",
+                    "command": [
+                        "s2i",
+                        "build",
+                        "$(inputs.params.PATH_CONTEXT)",
+                        "registry.access.redhat.com/rhscl/nodejs-$(inputs.params.VERSION)-rhel7",
+                        "--as-dockerfile",
+                        "/gen-source/Dockerfile.gen"
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ]
+                },
+                {
+                    "name": "build",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "bud",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "--layers",
+                        "-f",
+                        "/gen-source/Dockerfile.gen",
+                        "-t",
+                        "$(outputs.resources.image.url)",
+                        "."
+                    ],
+                    "workingDir": "/gen-source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        },
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                },
+                {
+                    "name": "push",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "push",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "$(outputs.resources.image.url)",
+                        "docker://$(outputs.resources.image.url)"
+                    ],
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "varlibcontainers",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "gen-source",
+                    "emptyDir": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "s2i-python-3",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/s2i-python-3",
+            "uid": "34a0225d-e0fc-40df-8f96-80673b08bded",
+            "resourceVersion": "78697",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:58Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "resources": [
+                    {
+                        "name": "source",
+                        "type": "git"
+                    }
+                ],
+                "params": [
+                    {
+                        "name": "MINOR_VERSION",
+                        "type": "string",
+                        "description": "The minor version of the python 3",
+                        "default": "6"
+                    },
+                    {
+                        "name": "PATH_CONTEXT",
+                        "type": "string",
+                        "description": "The location of the path to run s2i from.",
+                        "default": "."
+                    },
+                    {
+                        "name": "TLSVERIFY",
+                        "type": "string",
+                        "description": "Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)",
+                        "default": "true"
+                    }
+                ]
+            },
+            "outputs": {
+                "resources": [
+                    {
+                        "name": "image",
+                        "type": "image"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "generate",
+                    "image": "quay.io/openshift-pipeline/s2i:v0.8.0",
+                    "command": [
+                        "s2i",
+                        "build",
+                        "$(inputs.params.PATH_CONTEXT)",
+                        "registry.access.redhat.com/rhscl/python-3$(inputs.params.MINOR_VERSION)-rhel7",
+                        "--as-dockerfile",
+                        "/gen-source/Dockerfile.gen"
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ]
+                },
+                {
+                    "name": "build",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "bud",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "--layers",
+                        "-f",
+                        "/gen-source/Dockerfile.gen",
+                        "-t",
+                        "$(outputs.resources.image.url)",
+                        "."
+                    ],
+                    "workingDir": "/gen-source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        },
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                },
+                {
+                    "name": "push",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "push",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "$(outputs.resources.image.url)",
+                        "docker://$(outputs.resources.image.url)"
+                    ],
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "varlibcontainers",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "gen-source",
+                    "emptyDir": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "s2i-python-3-v0-8-0",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/s2i-python-3-v0-8-0",
+            "uid": "b23af17b-c770-43b6-af42-87afe5d4a846",
+            "resourceVersion": "78698",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:58Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "resources": [
+                    {
+                        "name": "source",
+                        "type": "git"
+                    }
+                ],
+                "params": [
+                    {
+                        "name": "MINOR_VERSION",
+                        "type": "string",
+                        "description": "The minor version of the python 3",
+                        "default": "6"
+                    },
+                    {
+                        "name": "PATH_CONTEXT",
+                        "type": "string",
+                        "description": "The location of the path to run s2i from.",
+                        "default": "."
+                    },
+                    {
+                        "name": "TLSVERIFY",
+                        "type": "string",
+                        "description": "Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)",
+                        "default": "true"
+                    }
+                ]
+            },
+            "outputs": {
+                "resources": [
+                    {
+                        "name": "image",
+                        "type": "image"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "generate",
+                    "image": "quay.io/openshift-pipeline/s2i:v0.8.0",
+                    "command": [
+                        "s2i",
+                        "build",
+                        "$(inputs.params.PATH_CONTEXT)",
+                        "registry.access.redhat.com/rhscl/python-3$(inputs.params.MINOR_VERSION)-rhel7",
+                        "--as-dockerfile",
+                        "/gen-source/Dockerfile.gen"
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ]
+                },
+                {
+                    "name": "build",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "bud",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "--layers",
+                        "-f",
+                        "/gen-source/Dockerfile.gen",
+                        "-t",
+                        "$(outputs.resources.image.url)",
+                        "."
+                    ],
+                    "workingDir": "/gen-source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        },
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                },
+                {
+                    "name": "push",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "push",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "$(outputs.resources.image.url)",
+                        "docker://$(outputs.resources.image.url)"
+                    ],
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "varlibcontainers",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "gen-source",
+                    "emptyDir": {}
+                }
+            ]
+        }
+    },
+    {
+        "kind": "ClusterTask",
+        "apiVersion": "tekton.dev/v1alpha1",
+        "metadata": {
+            "name": "s2i-v0-8-0",
+            "selfLink": "/apis/tekton.dev/v1alpha1/clustertasks/s2i-v0-8-0",
+            "uid": "db57f332-ab01-4380-a208-b27e05eaee6d",
+            "resourceVersion": "78671",
+            "generation": 1,
+            "creationTimestamp": "2020-01-20T17:39:54Z",
+            "annotations": {
+                "manifestival": "new"
+            },
+            "ownerReferences": [
+                {
+                    "apiVersion": "operator.tekton.dev/v1alpha1",
+                    "kind": "Config",
+                    "name": "cluster",
+                    "uid": "e595c575-4148-42b5-8d8b-44ee77f92d4c",
+                    "controller": true,
+                    "blockOwnerDeletion": true
+                }
+            ]
+        },
+        "spec": {
+            "inputs": {
+                "resources": [
+                    {
+                        "name": "source",
+                        "type": "git"
+                    }
+                ],
+                "params": [
+                    {
+                        "name": "BUILDER_IMAGE",
+                        "type": "string",
+                        "description": "The location of the s2i builder image."
+                    },
+                    {
+                        "name": "PATH_CONTEXT",
+                        "type": "string",
+                        "description": "The location of the path to run s2i from.",
+                        "default": "."
+                    },
+                    {
+                        "name": "TLSVERIFY",
+                        "type": "string",
+                        "description": "Verify the TLS on the registry endpoint (for push/pull to a non-TLS registry)",
+                        "default": "true"
+                    },
+                    {
+                        "name": "LOGLEVEL",
+                        "type": "string",
+                        "description": "Log level when running the S2I binary",
+                        "default": "0"
+                    }
+                ]
+            },
+            "outputs": {
+                "resources": [
+                    {
+                        "name": "image",
+                        "type": "image"
+                    }
+                ]
+            },
+            "steps": [
+                {
+                    "name": "generate",
+                    "image": "quay.io/openshift-pipeline/s2i:nightly",
+                    "command": [
+                        "/usr/local/bin/s2i",
+                        "--loglevel=$(inputs.params.LOGLEVEL)",
+                        "build",
+                        "$(inputs.params.PATH_CONTEXT)",
+                        "$(inputs.params.BUILDER_IMAGE)",
+                        "--as-dockerfile",
+                        "/gen-source/Dockerfile.gen"
+                    ],
+                    "workingDir": "/workspace/source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ]
+                },
+                {
+                    "name": "build",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "bud",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "--layers",
+                        "-f",
+                        "/gen-source/Dockerfile.gen",
+                        "-t",
+                        "$(outputs.resources.image.url)",
+                        "."
+                    ],
+                    "workingDir": "/gen-source",
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        },
+                        {
+                            "name": "gen-source",
+                            "mountPath": "/gen-source"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                },
+                {
+                    "name": "push",
+                    "image": "quay.io/buildah/stable",
+                    "command": [
+                        "buildah",
+                        "push",
+                        "--tls-verify=$(inputs.params.TLSVERIFY)",
+                        "$(outputs.resources.image.url)",
+                        "docker://$(outputs.resources.image.url)"
+                    ],
+                    "resources": {},
+                    "volumeMounts": [
+                        {
+                            "name": "varlibcontainers",
+                            "mountPath": "/var/lib/containers"
+                        }
+                    ],
+                    "securityContext": {
+                        "privileged": true
+                    }
+                }
+            ],
+            "volumes": [
+                {
+                    "name": "varlibcontainers",
+                    "emptyDir": {}
+                },
+                {
+                    "name": "gen-source",
+                    "emptyDir": {}
+                }
+            ]
+        }
+    }
+]

--- a/test/tkn.test.ts
+++ b/test/tkn.test.ts
@@ -978,6 +978,62 @@ suite("tkn", () => {
 
             expect(result[0].getName()).deep.equals('taskrun1');
         });
+
+        test('getRawClusterTasks returns items from tkn task list command', async () => {
+            const tknTasks = ['clustertask1', 'clustertask2'];
+            execStub.resolves({
+                error: null, stderr: '', stdout: JSON.stringify({
+                    "items": [{
+                        "kind": "ClusterTask",
+                        "apiVersion": "tekton.dev/v1alpha1",
+                        "metadata": {
+                            "name": "clustertask1"
+                        }
+                    }, {
+                        "kind": "Task",
+                        "apiVersion": "tekton.dev/v1alpha1",
+                        "metadata": {
+                            "name": "clustertask2"
+                        }
+                    }]
+                })
+            });
+            const result = await tknCli.getRawClusterTasks();
+
+            expect(execStub).calledOnceWith(tkn.Command.listClusterTasks());
+            expect(result.length).equals(2);
+            for (let i = 1; i < result.length; i++) {
+                expect(result[i].metadata.name).equals(tknTasks[i]);
+            }
+        });
+
+        test('getRawTasks returns items from tkn task list command', async () => {
+            const tknTasks = ['clustertask1', 'clustertask2'];
+            execStub.resolves({
+                error: null, stderr: '', stdout: JSON.stringify({
+                    "items": [{
+                        "kind": "ClusterTask",
+                        "apiVersion": "tekton.dev/v1alpha1",
+                        "metadata": {
+                            "name": "clustertask1"
+                        }
+                    }, {
+                        "kind": "Task",
+                        "apiVersion": "tekton.dev/v1alpha1",
+                        "metadata": {
+                            "name": "clustertask2"
+                        }
+                    }]
+                })
+            });
+            const result = await tknCli.getRawTasks();
+
+            expect(execStub).calledOnceWith(tkn.Command.listTasks());
+            expect(result.length).equals(2);
+            for (let i = 1; i < result.length; i++) {
+                expect(result[i].metadata.name).equals(tknTasks[i]);
+            }
+        });
     });
 
     suite('getPipelineNodes', () => {

--- a/test/yaml-support/scheme-storage.test.ts
+++ b/test/yaml-support/scheme-storage.test.ts
@@ -1,0 +1,62 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+import * as sinon from 'sinon';
+import { TknSchemeStorage } from '../../src/yaml-support/tkn-scheme-storage';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+suite('Scheme storage', () => {
+    let sandbox: sinon.SinonSandbox;
+    let schemeStorage: TknSchemeStorage;
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        schemeStorage = new TknSchemeStorage();
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('should call generator', async () => {
+        const doc = { getText: () => 'Some text', version: 1, uri: vscode.Uri.parse('file:///fos/bar.yaml') } as vscode.TextDocument;
+        const generator = sinon.fake.resolves('Foo');
+
+        const result = await schemeStorage.getScheme(doc, generator);
+        expect(result).equal('Foo');
+        expect(generator.calledOnce).to.be.true;
+    });
+
+    test('should check version', async () => {
+        const doc = { getText: () => 'Some text', version: 1, uri: vscode.Uri.parse('file:///fos/bar.yaml') } as vscode.TextDocument;
+        const generator = sinon.fake.resolves('Foo');
+
+        const result = await schemeStorage.getScheme(doc, generator);
+        const secondResult = await schemeStorage.getScheme(doc, generator);
+
+        expect(result).equal('Foo');
+        expect(generator.calledOnce).to.be.true;
+        expect(secondResult).equal('Foo');
+    });
+
+    test('should call generator if version changed', async () => {
+        const doc = { getText: () => 'Some text', version: 1, uri: vscode.Uri.parse('file:///fos/bar.yaml') } as vscode.TextDocument;
+        const generator = sinon.fake.resolves('Foo');
+
+        const result = await schemeStorage.getScheme(doc, generator);
+        const doc2 = { getText: () => 'Some text', version: 2, uri: vscode.Uri.parse('file:///fos/bar.yaml') } as vscode.TextDocument;
+
+        const secondResult = await schemeStorage.getScheme(doc2, generator);
+
+        expect(result).equal('Foo');
+        expect(generator.calledTwice).to.be.true;
+        expect(secondResult).equal('Foo');
+    });
+
+});

--- a/test/yaml-support/tasks-provider.test.ts
+++ b/test/yaml-support/tasks-provider.test.ts
@@ -2,7 +2,6 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
-import * as vscode from 'vscode';
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 import * as sinon from 'sinon';

--- a/test/yaml-support/tasks-provider.test.ts
+++ b/test/yaml-support/tasks-provider.test.ts
@@ -104,7 +104,7 @@ suite('Task provider', () => {
         }]);
     });
 
-    test('convertTasksToSnippet should not add params with default values', () => {
+    test('convertTasksToSnippet should add params with default values', () => {
         const result = taskProvider.convertTasksToSnippet([{
             "kind": "Task",
             metadata: {
@@ -123,7 +123,7 @@ suite('Task provider', () => {
         expect(result).to.eql([{
             label: 'CustomTask',
             description: 'Task',
-            body: { name: '$1', taskRef: { name: 'CustomTask' }, resources: { inputs: [{ name: 'barResource', resource: "$2" }] } }
+            body: { name: '$1', taskRef: { name: 'CustomTask' }, params: [{ name: 'fooParam', value: 'fooDefault' }], resources: { inputs: [{ name: 'barResource', resource: "$2" }] } }
         }]);
     });
 
@@ -137,7 +137,7 @@ suite('Task provider', () => {
                 steps: [],
                 inputs: {},
                 outputs: {
-                    resources: [{name: 'Foo', type: 'Bar'}],
+                    resources: [{ name: 'Foo', type: 'Bar' }],
                 }
             }
         }]);

--- a/test/yaml-support/tasks-provider.test.ts
+++ b/test/yaml-support/tasks-provider.test.ts
@@ -1,0 +1,152 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+import * as vscode from 'vscode';
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+import * as sinon from 'sinon';
+import * as taskProvider from '../../src/yaml-support/tkn-tasks-provider';
+import * as tkn from '../../src/tkn';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+suite('Task provider', () => {
+    let sandbox: sinon.SinonSandbox;
+    let execStub: sinon.SinonStub;
+    const tknCli: tkn.Tkn = tkn.TknImpl.Instance;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+        execStub = sandbox.stub(tknCli, 'execute');
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    test('should receive tasks from tkn', async () => {
+        execStub.resolves();
+
+        execStub.onCall(0).resolves({
+            error: null, stderr: '', stdout: JSON.stringify({
+                "items": [{
+                    "kind": "ClusterTask",
+                    "apiVersion": "tekton.dev/v1alpha1",
+                    "metadata": {
+                        "name": "clustertask1"
+                    },
+                    "spec": {
+
+                    }
+                }]
+            })
+        });
+
+        execStub.onCall(1).resolves({
+            error: null, stderr: '', stdout: JSON.stringify({
+                "items": [{
+                    "kind": "Task",
+                    "apiVersion": "tekton.dev/v1alpha1",
+                    "metadata": {
+                        "name": "clustertask2"
+                    },
+                    "spec": {
+
+                    }
+                }]
+            })
+        });
+
+        const snippets = await taskProvider.getTknTasksSnippets();
+
+        expect(snippets.length).to.equal(2);
+
+    });
+
+
+    test('convertTasksToSnippet should return snippets', () => {
+        const result = taskProvider.convertTasksToSnippet([{
+            "kind": "Task",
+            metadata: {
+                name: "CustomTask"
+            },
+            spec: {
+                steps: [],
+                inputs: {},
+                outputs: {}
+            }
+        }]);
+
+        expect(result).to.eql([{ label: 'CustomTask', description: 'Task', body: { name: '$1', taskRef: { name: 'CustomTask' } } }]);
+    });
+
+    test('convertTasksToSnippet should convert inputs ', () => {
+        const result = taskProvider.convertTasksToSnippet([{
+            "kind": "Task",
+            metadata: {
+                name: "CustomTask"
+            },
+            spec: {
+                steps: [],
+                inputs: {
+                    params: [{ name: 'fooParam' }],
+                    resources: [{ name: 'barResource', type: 'barType' }]
+                },
+                outputs: {}
+            }
+        }]);
+
+        expect(result).to.eql([{
+            label: 'CustomTask',
+            description: 'Task',
+            body: { name: '$1', taskRef: { name: 'CustomTask' }, params: [{ name: 'fooParam', value: '$2' }], resources: { inputs: [{ name: 'barResource', resource: "$3" }] } }
+        }]);
+    });
+
+    test('convertTasksToSnippet should not add params with default values', () => {
+        const result = taskProvider.convertTasksToSnippet([{
+            "kind": "Task",
+            metadata: {
+                name: "CustomTask"
+            },
+            spec: {
+                steps: [],
+                inputs: {
+                    params: [{ name: 'fooParam', default: 'fooDefault' }],
+                    resources: [{ name: 'barResource', type: 'barType' }]
+                },
+                outputs: {}
+            }
+        }]);
+
+        expect(result).to.eql([{
+            label: 'CustomTask',
+            description: 'Task',
+            body: { name: '$1', taskRef: { name: 'CustomTask' }, resources: { inputs: [{ name: 'barResource', resource: "$2" }] } }
+        }]);
+    });
+
+    test('convertTasksToSnippet should add output', () => {
+        const result = taskProvider.convertTasksToSnippet([{
+            "kind": "Task",
+            metadata: {
+                name: "CustomTask"
+            },
+            spec: {
+                steps: [],
+                inputs: {},
+                outputs: {
+                    resources: [{name: 'Foo', type: 'Bar'}],
+                }
+            }
+        }]);
+
+        expect(result).to.eql([{
+            label: 'CustomTask',
+            description: 'Task',
+            body: { name: '$1', taskRef: { name: 'CustomTask' }, resources: { outputs: [{ name: 'Foo', resource: "$2" }] } }
+        }]);
+    });
+});

--- a/test/yaml-support/tkn-yaml.test.ts
+++ b/test/yaml-support/tkn-yaml.test.ts
@@ -1,0 +1,178 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+import * as vscode from 'vscode';
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+import * as sinon from 'sinon';
+import { isTektonYaml, TektonYamlType, getPipelineTasksRefName, getPipelineTasksName, getDeclaredResources } from '../../src/yaml-support/tkn-yaml';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+suite('Tekton yaml', () => {
+    let sandbox: sinon.SinonSandbox;
+
+    setup(() => {
+        sandbox = sinon.createSandbox();
+    });
+
+    teardown(() => {
+        sandbox.restore();
+    });
+
+    suite('Tekton detection', () => {
+        test('Should detect Pipeline', () => {
+
+            const yaml = `
+            apiVersion: tekton.dev/v1alpha1
+            kind: Pipeline
+            metadata:
+              name: pipeline-with-parameters
+            spec:
+              params:
+                - name: context
+                  type: string
+                  description: Path to context
+                  default: /some/where/or/other
+              tasks:
+                - name: build-skaffold-web
+                  taskRef:
+                    name: build-push
+                  params:
+                    - name: pathToDockerFile
+                      value: Dockerfile
+                    - name: pathToContext
+                      value: "$(params.context)"
+            `
+            const tknType = isTektonYaml({ getText: () => yaml, version: 1, uri: vscode.Uri.parse('file:///foo/bar.yaml') } as vscode.TextDocument);
+            expect(tknType).is.not.undefined;
+            expect(tknType).to.equals(TektonYamlType.Pipeline);
+        });
+
+        test('Should not detect if kind not Pipeline', () => {
+            const yaml = `
+            apiVersion: tekton.dev/v1alpha1
+            kind: PipeFoo
+            metadata:
+              name: pipeline-with-parameters
+            spec:
+              params:
+                - name: context
+                  type: string
+                  description: Path to context
+                  default: /some/where/or/other
+              tasks:
+                - name: build-skaffold-web
+                  taskRef:
+                    name: build-push
+                  params:
+                    - name: pathToDockerFile
+                      value: Dockerfile
+                    - name: pathToContext
+                      value: "$(params.context)"
+            `
+            const tknType = isTektonYaml({ getText: () => yaml, version: 1, uri: vscode.Uri.parse('file:///foo/NotBar.yaml') } as vscode.TextDocument);
+            expect(tknType).is.undefined;
+        });
+
+    });
+
+    suite('Tekton tasks detections', () => {
+        test('should return Tekton tasks ref names', () => {
+            const yaml = `
+            apiVersion: tekton.dev/v1alpha1
+            kind: Pipeline
+            metadata:
+              name: pipeline-with-parameters
+            spec:
+              tasks:
+                - name: build-skaffold-web
+                  taskRef:
+                    name: build-push
+                  params:
+                    - name: pathToDockerFile
+                      value: Dockerfile
+                    - name: pathToContext
+                      value: "$(params.context)"
+            `
+            const pipelineTasks = getPipelineTasksRefName({ getText: () => yaml, version: 1, uri: vscode.Uri.parse('file:///foo/pipeline/tasks.yaml') } as vscode.TextDocument);
+            expect(pipelineTasks).is.not.empty;
+            expect(pipelineTasks).to.eql(['build-push']);
+        });
+
+        test('should return empty array if no tasks defined', () => {
+            const yaml = `
+            apiVersion: tekton.dev/v1alpha1
+            kind: Pipeline
+            metadata:
+              name: pipeline-with-parameters
+            spec:
+              tasks:
+            `
+            const pipelineTasks = getPipelineTasksRefName({ getText: () => yaml, version: 1, uri: vscode.Uri.parse('file:///foo/pipeline/empty/tasks.yaml') } as vscode.TextDocument);
+            expect(pipelineTasks).is.empty;
+        });
+
+        test('should return tekton pipeline tasks names', () => {
+            const yaml = `
+          apiVersion: tekton.dev/v1alpha1
+          kind: Pipeline
+          metadata:
+            name: pipeline-with-parameters
+          spec:
+            tasks:
+              - name: build-skaffold-web
+                taskRef:
+                  name: build-push
+                params:
+                  - name: pathToDockerFile
+                    value: Dockerfile
+                  - name: pathToContext
+                    value: "$(params.context)"
+          `
+            const pipelineTasks = getPipelineTasksName({ getText: () => yaml, version: 1, uri: vscode.Uri.parse('file:///foo/pipeline/tasks.yaml') } as vscode.TextDocument);
+            expect(pipelineTasks).is.not.empty;
+            expect(pipelineTasks).to.eql(['build-skaffold-web']);
+        });
+    });
+
+    suite('Tekton Declared resource detection', () => {
+        test('Should return declared pipeline resources', () => {
+            const yaml = `
+            apiVersion: tekton.dev/v1alpha1
+            kind: Pipeline
+            metadata:
+              name: build-and-deploy
+            spec:
+              resources:
+                - name: api-repo
+                  type: git
+                - name: api-image
+                  type: image
+            
+              tasks:
+                - name: build-api
+                  taskRef:
+                    name: buildah
+                    kind: ClusterTask
+                  resources:
+                    inputs:
+                      - name: source
+                        resource: api-repo
+                    outputs:
+                      - name: image
+                        resource: api-image
+                  params:
+                    - name: TLSVERIFY
+                      value: "false"
+            `;
+
+            const pipelineResources = getDeclaredResources({ getText: () => yaml, version: 1, uri: vscode.Uri.parse('file:///foo/pipeline/resources.yaml') } as vscode.TextDocument);
+            expect(pipelineResources).is.not.empty;
+            expect(pipelineResources).to.eql([{name: "api-repo", type: "git"}, {name: "api-image", type: "image"}]);
+        });
+    });
+
+});


### PR DESCRIPTION
For #121

This PR provide JSON scheme for Pipeline yaml and use `vscode-yaml` extension to validate it over pipeline yaml file. 
It also provide snippets for all available tasks, it uses [defaultSnippets](https://code.visualstudio.com/docs/languages/json#_define-snippets-in-json-schemas) feature , `vscode-yaml` will provide code completion for that tasks.
It also add some basic semantic validation over pipeline definition, see demos.

Demo:

Completion of  available/deployed tasks:
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/929743/73345947-aab48280-428d-11ea-941f-bfd3a51ff706.gif)

> Note: `vscode-yaml`/`yaml-language-server` still not correctly generate yaml snippet from json object, issue: https://github.com/redhat-developer/yaml-language-server/issues/225

Completion of available/deployed tasks for `taskRef` :
![ezgif com-video-to-gif (2)](https://user-images.githubusercontent.com/929743/73346138-0848cf00-428e-11ea-9c27-e0bc6ad7c262.gif)

Completion of `runAfter ` values:
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/929743/73346433-83aa8080-428e-11ea-84f0-26a0a7c0e410.gif)
> Node: it seems that there some bug in `yaml-language-server`, it combines two different enums from json scheme, need to investigate...

Completion of `resource` value for `input` and `output`, based on resources defined in pipeline yaml:
![ezgif com-video-to-gif (4)](https://user-images.githubusercontent.com/929743/73346641-e69c1780-428e-11ea-9a9f-997346f6e430.gif)

Validation of task `name` and it usage in `runAfter` and `taskRef`:
![ezgif com-video-to-gif (5)](https://user-images.githubusercontent.com/929743/73346766-19dea680-428f-11ea-8b17-4897ae0a5d16.gif)

