### PR TITLE
Add preview tag to true for change in marketplace

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "publisher": "redhat",
   "author": "Red Hat",
+  "preview": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/redhat-developer/vscode-tekton.git"


### PR DESCRIPTION
This change is necessary as all the extensions in VSCode Marketplace supported by Red Hat should be in `Preview` state.