### PR TITLE
Fix test fail

### DIFF
--- a/test/util/tektonresources.virtualfs.test.ts
+++ b/test/util/tektonresources.virtualfs.test.ts
@@ -110,7 +110,7 @@ suite('TektonResourceVirtualFileSystemProvider', () => {
     unlinkStub = sandbox.stub(fs, 'unlink');
     openTextStub = sandbox.stub(workspace, 'openTextDocument').resolves(textDocument);
     executeCommandStub = sandbox.stub(commands, 'executeCommand');
-    nonce = sinon.useFakeTimers({
+    nonce = sandbox.useFakeTimers({
       now: new Date(),
       shouldAdvanceTime: true
     });


### PR DESCRIPTION
We have CI test failures with message:
```
Error: async hook stack has become corrupted (actual: 1610, expected: 0)
...
[main 2020-03-12T13:44:02.534Z] [VS Code]: render process crashed!
```

This pr try to fix that error