### PR TITLE
Enable 'eol-last' eslint rule as error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,8 @@ module.exports = {
         '@typescript-eslint/no-unused-vars': [1],
         "@typescript-eslint/explicit-function-return-type": [1, { "allowExpressions": true }],
         "indent": ["error", 2, { "SwitchCase": 1 }],
-        "quotes": ["error", "single"]
+        "quotes": ["error", "single"],
+        "eol-last": ["error"]
     },
 
 };


### PR DESCRIPTION
This PR enable [eol-last](https://eslint.org/docs/rules/eol-last) eslint rule and make error if file doesn't contain new line at end of the file