### PR TITLE
add new cli run with watch feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1426,6 +1426,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "clarinet": {
+      "version": "0.12.4",
+      "resolved": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.4.tgz",
+      "integrity": "sha512-Rx9Zw8KQkoPO3/O2yPRchCZm3cGubCQiRLmmFAlbkDKobUIPP3JYul+bKILR9DIv1gSVwPQSgF8JGGkXzX8Q0w=="
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -4456,6 +4461,14 @@
         "extsprintf": "1.3.0",
         "json-schema": "0.2.3",
         "verror": "1.10.0"
+      }
+    },
+    "jstream": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jstream/-/jstream-1.1.1.tgz",
+      "integrity": "sha512-8CGzeO6reMPuQARiJoHqOooYoqhNthAb4CuZNCrOYeU0UTKha7KYzXRy1+4o5UpjlP7FhZb11J9Yc8MUVozS5g==",
+      "requires": {
+        "clarinet": "~0.12.0"
       }
     },
     "just-extend": {

--- a/package.json
+++ b/package.json
@@ -826,6 +826,7 @@
     "git-transport-protocol": "^0.1.0",
     "hasha": "5.0.0",
     "humanize-duration": "^3.21.0",
+    "jstream": "^1.1.1",
     "lodash": "^4.17.15",
     "mkdirp": "^0.5.1",
     "node-yaml-parser": "0.0.9",

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -1,0 +1,45 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { newK8sCommand, PipelineRunData } from './tkn';
+import { CliImpl, CliCommand } from './cli';
+
+export const KubectlCommands = {
+  watchPipelineRuns(name: string): CliCommand {
+    return newK8sCommand('get', 'pipelinerun', name, '-w', '-o', 'json');
+  }
+}
+
+export type PipelineRunCallback = (pr: PipelineRunData) => void;
+
+export class Kubectl {
+  watchPipelineRun(name: string, callback?: PipelineRunCallback): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const watch = CliImpl.getInstance().executeWatchJSO(KubectlCommands.watchPipelineRuns(name));
+      watch.on('object', obj => {
+        if (callback) {
+          callback(obj);
+        }
+        if (obj.status?.completionTime !== undefined) {
+          watch.kill(); // PipelineRun finished
+        }
+      });
+
+      watch.stderr.on('data', data => {
+        reject(data); // TODO: better error handling
+      });
+
+      watch.on('close', code => {
+        if (code == 0) {
+          resolve();
+        } else {
+          reject(`Watch command exited with code: ${code}`);
+        }
+      })
+    });
+  }
+}
+
+export const kubectl = new Kubectl();

--- a/src/tekton/pipelinerun.ts
+++ b/src/tekton/pipelinerun.ts
@@ -7,6 +7,7 @@ import { TektonItem } from './tektonitem';
 import { TektonNode, Command } from '../tkn';
 import { window } from 'vscode';
 import { Progress } from '../util/progress';
+import { kubectl } from '../kubectl';
 
 export class PipelineRun extends TektonItem {
 

--- a/src/tkn.ts
+++ b/src/tkn.ts
@@ -92,7 +92,7 @@ function newTknCommand(...tknArguments: string[]): CliCommand {
   return createCliCommand('tkn', ...tknArguments);
 }
 
-function newK8sCommand(...k8sArguments): CliCommand {
+export function newK8sCommand(...k8sArguments): CliCommand {
   return createCliCommand('kubectl', ...k8sArguments);
 }
 
@@ -486,7 +486,7 @@ export class TaskRun extends TektonNodeImpl {
 }
 
 
-type PipelineRunData = {
+export type PipelineRunData = {
   metadata: {
     creationTimestamp: string;
     name: string;


### PR DESCRIPTION
This PR add new API to run cli with watch feature, and support of cli output streaming as JS objects parsed from output.

Also it include sample implementation of `kubectl get pipelinerun  ${pr-name} -w -o json` command, 
we can use that command to track changes of pipeline run status.
sample of usage: 

```typescript
import {kubectl} from 'kubectl';
...

await kubectl.watchPipelineRun('my-super-pipeline-run-name'); // resolves when pipelinerun finished


await kubectl.watchPipelineRun('my-super-pipeline-run-name', pr => {
   // pr is a 'PipelineRun' object, this callback will be called on each status change
}); // resolves when pipelinerun finished


```

Should be used for: https://github.com/redhat-developer/vscode-tekton/pull/190 and https://github.com/redhat-developer/vscode-tekton/issues/175