### PR TITLE
Delay reporting test finish

### DIFF
--- a/build/install-vscode.ts
+++ b/build/install-vscode.ts
@@ -7,7 +7,7 @@ import cp = require('child_process');
 import path = require('path');
 import { platform } from 'os';
 const downloadAndUnzipVSCode = require('vscode-test').downloadAndUnzipVSCode;
-downloadAndUnzipVSCode().then((executable: string) => {
+downloadAndUnzipVSCode('1.42.1').then((executable: string) => {
   if (platform() === 'darwin') {
     executable = `'${path.join(executable.substring(0, executable.indexOf('.app') + 4), 'Contents', 'Resources', 'app', 'bin', 'code')}'`;
   } else {

--- a/build/install-vscode.ts
+++ b/build/install-vscode.ts
@@ -7,7 +7,7 @@ import cp = require('child_process');
 import path = require('path');
 import { platform } from 'os';
 const downloadAndUnzipVSCode = require('vscode-test').downloadAndUnzipVSCode;
-downloadAndUnzipVSCode('1.42.1').then((executable: string) => {
+downloadAndUnzipVSCode().then((executable: string) => {
   if (platform() === 'darwin') {
     executable = `'${path.join(executable.substring(0, executable.indexOf('.app') + 4), 'Contents', 'Resources', 'app', 'bin', 'code')}'`;
   } else {

--- a/build/unit-tests.ts
+++ b/build/unit-tests.ts
@@ -20,7 +20,7 @@ async function main(): Promise<void> {
     // Download VS Code, unzip it and run the integration test
     console.log(extensionDevelopmentPath, extensionTestsPath);
     await runTests({
-      extensionDevelopmentPath, extensionTestsPath, version: '1.42.1',
+      extensionDevelopmentPath, extensionTestsPath,
       launchArgs: [
         // This disables all extensions except the one being testing
         // '--disable-extensions',

--- a/build/unit-tests.ts
+++ b/build/unit-tests.ts
@@ -20,7 +20,7 @@ async function main(): Promise<void> {
     // Download VS Code, unzip it and run the integration test
     console.log(extensionDevelopmentPath, extensionTestsPath);
     await runTests({
-      extensionDevelopmentPath, extensionTestsPath,
+      extensionDevelopmentPath, extensionTestsPath, version: '1.42.1',
       launchArgs: [
         // This disables all extensions except the one being testing
         // '--disable-extensions',

--- a/test/index.ts
+++ b/test/index.ts
@@ -85,7 +85,7 @@ export function run(): Promise<void> {
               } else {
                 resolve();
               }
-            }, 1000);
+            }, 5000);
           });
   
         } catch (err) {

--- a/test/index.ts
+++ b/test/index.ts
@@ -78,6 +78,7 @@ export function run(): Promise<void> {
             testFailures = failures;
           }).on('end', () => {
             coverageRunner && coverageRunner.reportCoverage();
+            // delay reporting that test are finished, to let main process handle all output
             setTimeout(()=> {
               if (testFailures > 0) {
                 reject(new Error(`${testFailures} tests failed.`));


### PR DESCRIPTION
For some reason on macOS vscode kill `extensionHost` nodeJS instance before main process able to process output from test. This PR add delay to let main vscode process handle test output. Also it make sure that we generate test code coverage report before report that test are finished.

Also it return run test on latest vscode version.

Fix: #221