### PR TITLE
 Add commands to get PipelineRun and TaskRun logs in to k8s tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,13 +137,23 @@
     ],
     "commands": [
       {
-				"command": "tekton.edit",
-				"title": "Open In Editor",
-				"icon": {
-					"light": "images/light/go-to-file.svg",
-					"dark": "images/dark/go-to-file.svg"
-				}
-			},
+        "command": "k8s.tekton.run.logs",
+        "title": "Show Logs",
+        "category": "Kubernetes"
+      },
+      {
+        "command": "k8s.tekton.run.followLogs",
+        "title": "Follow Logs",
+        "category": "Kubernetes"
+      },
+      {
+        "command": "tekton.edit",
+        "title": "Open In Editor",
+        "icon": {
+          "light": "images/light/go-to-file.svg",
+          "dark": "images/dark/go-to-file.svg"
+        }
+      },
       {
         "command": "tekton.pipeline.preview",
         "title": "Open Pipeline preview to the Side",
@@ -556,6 +566,16 @@
       ],
       "view/item/context": [
         {
+          "command": "k8s.tekton.run.logs",
+          "when": "viewItem =~ /vsKubernetes\\.resource\\.(pipelinerun|taskrun)/i",
+          "group": "c1@1"
+        },
+        {
+          "command": "k8s.tekton.run.followLogs",
+          "when": "viewItem =~ /vsKubernetes\\.resource\\.(pipelinerun|taskrun)/i",
+          "group": "c1@2"
+        },
+        {
           "command": "tekton.pipeline.restart",
           "when": "view =~ /^tekton(CustomTree|PipelineExplorer)View/ && viewItem == pipeline",
           "group": "c1@1"
@@ -716,9 +736,9 @@
           "group": "c2"
         },
         {
-					"command": "tekton.edit",
+          "command": "tekton.edit",
           "when": "view =~ /^tekton(CustomTree|PipelineExplorer)View/ && viewItem =~ /^(pipeline|pipelinerun|clustertask|pipelineresource|taskrun|triggertemplates|triggerbinding|eventlistener|conditions|task)$/",
-					"group": "inline"
+          "group": "inline"
         },
         {
           "command": "tekton.openInEditor",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,6 +25,7 @@ import { showPipelinePreview, registerPipelinePreviewContext } from './pipeline/
 import { TriggerTemplate } from './tekton/triggertemplate';
 import { TriggerBinding } from './tekton/triggerbinding';
 import { EventListener } from './tekton/eventlistener';
+import { k8sCommands } from './kubernetes';
 
 export let contextGlobalState: vscode.ExtensionContext;
 let tektonExplorer: k8s.ClusterExplorerV1 | undefined = undefined;
@@ -81,6 +82,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     vscode.commands.registerCommand('tekton.custom.explorer.exitZenMode', exitZenMode),
     vscode.commands.registerCommand('tekton.custom.explorer.refresh', refreshCustomTree),
     vscode.commands.registerCommand('tekton.custom.explorer.removeItem', removeItemFromCustomTree),
+    vscode.commands.registerCommand('k8s.tekton.run.logs', k8sCommands.showLogs),
+    vscode.commands.registerCommand('k8s.tekton.run.followLogs', k8sCommands.followLogs),
     pipelineExplorer,
     // Temporarily loaded resource providers
     vscode.workspace.registerFileSystemProvider(TKN_RESOURCE_SCHEME, resourceDocProvider, { /* TODO: case sensitive? */ }),

--- a/src/kubernetes.ts
+++ b/src/kubernetes.ts
@@ -1,0 +1,46 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import { Command, tknInstance as tkn } from './tkn';
+
+interface K8sClusterExplorerItem {
+  nodeType: 'resource';
+  nodeCategory?: string;
+  kind: K8sClusterExplorerItemKind;
+  name: string;
+  kindName?: string;
+}
+
+interface K8sClusterExplorerItemKind {
+  displayName?: string;
+  pluralDisplayName?: string;
+  manifestKind?: string;
+  abbreviation?: string;
+}
+
+class K8sCommands {
+  showLogs(context: K8sClusterExplorerItem): void {
+    if (context?.kind?.abbreviation === 'taskruns') {
+      tkn.executeInTerminal(Command.showTaskRunLogs(context.name));
+    } else if (context?.kind?.abbreviation === 'pipelineruns') {
+      tkn.executeInTerminal(Command.showPipelineRunLogs(context.name));
+    } else {
+      throw new Error(`Can't handle log request for ${context.name}`);
+    }
+  }
+
+  followLogs(context: K8sClusterExplorerItem): void {
+    if (context?.kind?.abbreviation === 'taskruns') {
+      tkn.executeInTerminal(Command.showTaskRunFollowLogs(context.name));
+    } else if (context?.kind?.abbreviation === 'pipelineruns') {
+      tkn.executeInTerminal(Command.showPipelineRunFollowLogs(context.name));
+    } else {
+      throw new Error(`Can't handle log request for ${context.name}`);
+    }
+  }
+}
+
+export const k8sCommands = new K8sCommands();
+

--- a/test/kubernetes.test.ts
+++ b/test/kubernetes.test.ts
@@ -1,0 +1,71 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+import * as sinon from 'sinon';
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+import * as tkn from '../src/tkn';
+import { k8sCommands } from '../src/kubernetes';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+suite('Kubernetos', () => {
+  const sandbox = sinon.createSandbox();
+
+  suite('K8s commands', () => {
+    let executeInTerminalStub: sinon.SinonStub;
+    setup(() => {
+      executeInTerminalStub = sandbox.stub(tkn.tknInstance, 'executeInTerminal');
+    });
+
+    teardown(() => {
+      sandbox.restore();
+    });
+
+    test('k8s.tekton.run.logs should call showTaskRunLogs if context is taskruns', () => {
+      const command = tkn.Command.showTaskRunLogs('foo');
+      k8sCommands.showLogs({ name: 'foo', nodeType: 'resource', kind: { abbreviation: 'taskruns' } });
+      expect(executeInTerminalStub).calledOnceWith(command);
+    });
+
+    test('k8s.tekton.run.logs should call showPipelineRunLogs if context is pipelineruns', () => {
+      const command = tkn.Command.showPipelineRunLogs('foo');
+      k8sCommands.showLogs({ name: 'foo', nodeType: 'resource', kind: { abbreviation: 'pipelineruns' } });
+      expect(executeInTerminalStub).calledOnceWith(command);
+    });
+
+    test('k8s.tekton.run.logs should throw error if it can\'t find proper type', () => {
+      try {
+        k8sCommands.showLogs({ name: 'foo', nodeType: 'resource', kind: { abbreviation: 'foobar' } });
+      } catch (err) {
+        expect
+      }
+      expect(k8sCommands.showLogs.bind(k8sCommands, { name: 'foo', nodeType: 'resource', kind: { abbreviation: 'foobar' } })).to.throw('Can\'t handle log request for foo');
+
+    });
+
+    test('k8s.tekton.run.followLogs should call showTaskRunLogs if context is taskruns', () => {
+      const command = tkn.Command.showTaskRunFollowLogs('foo');
+      k8sCommands.followLogs({ name: 'foo', nodeType: 'resource', kind: { abbreviation: 'taskruns' } });
+      expect(executeInTerminalStub).calledOnceWith(command);
+    });
+
+    test('k8s.tekton.run.followLogs should call showPipelineRunLogs if context is pipelineruns', () => {
+      const command = tkn.Command.showPipelineRunFollowLogs('foo');
+      k8sCommands.followLogs({ name: 'foo', nodeType: 'resource', kind: { abbreviation: 'pipelineruns' } });
+      expect(executeInTerminalStub).calledOnceWith(command);
+    });
+
+    test('k8s.tekton.run.followLogs should throw error if it can\'t find proper type', () => {
+      try {
+        k8sCommands.followLogs({ name: 'foo', nodeType: 'resource', kind: { abbreviation: 'foobar' } });
+      } catch (err) {
+        expect
+      }
+      expect(k8sCommands.followLogs.bind(k8sCommands, { name: 'foo', nodeType: 'resource', kind: { abbreviation: 'foobar' } })).to.throw('Can\'t handle log request for foo');
+
+    });
+  });
+});


### PR DESCRIPTION
This PR adds two commands `Show Log` and `Follow Logs` in kubernetos tree for PipelineRun and TaskRun items:
> Note: Getting logs implemented with `tkn` cli (exactly the dame as for Tekton tree), it is possible to fetch logs using pure kubernetos API but it requires a big effort, basically we need to re implement part of `tkn` CLI: https://github.com/tektoncd/cli/blob/6dad772d2bd697c0f66ec404a4db73b449b2cfa3/pkg/log/task_reader.go#L101
https://github.com/tektoncd/cli/blob/6dad772d2bd697c0f66ec404a4db73b449b2cfa3/pkg/log/pipeline_reader.go#L85

<img width="320" alt="Screenshot 2020-04-14 at 15 30 42" src="https://user-images.githubusercontent.com/929743/79225695-c92a2300-7e65-11ea-9896-82ea9b469947.png">
<img width="320" alt="Screenshot 2020-04-14 at 15 30 24" src="https://user-images.githubusercontent.com/929743/79225703-cd564080-7e65-11ea-878d-3c97b53f8c5e.png">

Fix: #2