### PR TITLE
Use 'kubectl' instead of 'tkn' for tree, some minor refactoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7392,9 +7392,9 @@
       "dev": true
     },
     "vscode-kubernetes-tools-api": {
-      "version": "1.0.0",
-      "resolved": "http://localhost:8080/vscode-kubernetes-tools-api/-/vscode-kubernetes-tools-api-1.0.0.tgz",
-      "integrity": "sha512-f9nmtYMZ32Dsmr4r0LoJ/JRl//gMsXqjYujOFQJg/dbIIFQMrUKOL+8+EWAz1h8rqgvMsj1NatSIThUFNlL65A=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-kubernetes-tools-api/-/vscode-kubernetes-tools-api-1.1.0.tgz",
+      "integrity": "sha512-b51Rc7HLK4yrOADgW8Ok4YWM+utUGuXUA1Zf/a2ub2cUDH4/W+ndrViAKo1+YUOVbYoq+TbNMWevCUQVvhqvxQ=="
     },
     "vscode-test": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -849,6 +849,6 @@
     "targz": "^1.0.1",
     "unzip-stream": "^0.3.0",
     "validator": "^11.0.0",
-    "vscode-kubernetes-tools-api": "1.0.0"
+    "vscode-kubernetes-tools-api": "1.1.0"
   }
 }

--- a/src/kubectl.ts
+++ b/src/kubectl.ts
@@ -4,7 +4,7 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { newK8sCommand } from './tkn';
-import { CliImpl, CliCommand } from './cli';
+import { CliCommand, cli} from './cli';
 import { PipelineRunData } from './tekton';
 
 export const KubectlCommands = {
@@ -24,7 +24,7 @@ export interface WatchControl {
 export class Kubectl {
   watchPipelineRun(name: string, callback?: PipelineRunCallback): Promise<void> {
     return new Promise((resolve, reject) => {
-      const watch = CliImpl.getInstance().executeWatchJSON(KubectlCommands.watchPipelineRuns(name));
+      const watch = cli.executeWatchJSON(KubectlCommands.watchPipelineRuns(name));
       watch.on('object', obj => {
         if (callback) {
           callback(obj);
@@ -50,7 +50,7 @@ export class Kubectl {
   }
 
   watchPipelineRunWithControl(name: string, callback?: PipelineRunCallback): WatchControl {
-    const watch = CliImpl.getInstance().executeWatchJSON(KubectlCommands.watchPipelineRuns(name));
+    const watch = cli.executeWatchJSON(KubectlCommands.watchPipelineRuns(name));
     const finish = new Promise<void>((resolve, reject) => {
       watch.on('object', obj => {
         if (callback) {

--- a/src/kubernetes.ts
+++ b/src/kubernetes.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { Command, tknInstance as tkn } from './tkn';
+import { Command, tkn as tkn } from './tkn';
 
 interface K8sClusterExplorerItem {
   nodeType: 'resource';

--- a/src/pipeline/pipelineExplorer.ts
+++ b/src/pipeline/pipelineExplorer.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { TreeDataProvider, TreeView, Event, EventEmitter, TreeItem, ProviderResult, Disposable, window, extensions, commands, Uri, version } from 'vscode';
+import { TreeDataProvider, TreeView, Event, EventEmitter, TreeItem, ProviderResult, Disposable, window, extensions, commands, Uri, version, TreeItemCollapsibleState } from 'vscode';
 import { TektonNode, MoreNode, tkn } from '../tkn';
 import { WatchUtil, FileContentChangeNotifier } from '../util/watch';
 import { Platform } from '../util/platform';
@@ -21,6 +21,13 @@ export class PipelineExplorer implements TreeDataProvider<TektonNode>, Disposabl
     this.fsw = WatchUtil.watchFileForContextChange(kubeConfigFolder, 'config');
     this.fsw.emitter.on('file-changed', this.refresh.bind(this));
     this.treeView = window.createTreeView('tektonPipelineExplorerView', { treeDataProvider: this, canSelectMany: true });
+    this.treeView.onDidExpandElement(e => {
+      e.element.collapsibleState = TreeItemCollapsibleState.Expanded;
+    });
+
+    this.treeView.onDidCollapseElement(e => {
+      e.element.collapsibleState = TreeItemCollapsibleState.Collapsed;
+    });
   }
 
   getTreeItem(element: TektonNode): TreeItem | Thenable<TreeItem> {

--- a/src/pipeline/pipelineExplorer.ts
+++ b/src/pipeline/pipelineExplorer.ts
@@ -4,7 +4,7 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import { TreeDataProvider, TreeView, Event, EventEmitter, TreeItem, ProviderResult, Disposable, window, extensions, commands, Uri, version } from 'vscode';
-import { TektonNode, MoreNode, tknInstance } from '../tkn';
+import { TektonNode, MoreNode, tkn } from '../tkn';
 import { WatchUtil, FileContentChangeNotifier } from '../util/watch';
 import { Platform } from '../util/platform';
 import * as path from 'path';
@@ -34,7 +34,7 @@ export class PipelineExplorer implements TreeDataProvider<TektonNode>, Disposabl
     if (element) {
       return element.getChildren();
     } else {
-      return tknInstance.getPipelineNodes();
+      return tkn.getPipelineNodes();
     }
 
   }
@@ -44,9 +44,6 @@ export class PipelineExplorer implements TreeDataProvider<TektonNode>, Disposabl
   }
 
   refresh(target?: TektonNode): void {
-    if (!target) {
-      tknInstance.clearCache();
-    }
     this.onDidChangeTreeDataEmitter.fire(target);
   }
 

--- a/src/pipeline/pipelineExplorer.ts
+++ b/src/pipeline/pipelineExplorer.ts
@@ -21,13 +21,6 @@ export class PipelineExplorer implements TreeDataProvider<TektonNode>, Disposabl
     this.fsw = WatchUtil.watchFileForContextChange(kubeConfigFolder, 'config');
     this.fsw.emitter.on('file-changed', this.refresh.bind(this));
     this.treeView = window.createTreeView('tektonPipelineExplorerView', { treeDataProvider: this, canSelectMany: true });
-    this.treeView.onDidExpandElement(e => {
-      e.element.collapsibleState = TreeItemCollapsibleState.Expanded;
-    });
-
-    this.treeView.onDidCollapseElement(e => {
-      e.element.collapsibleState = TreeItemCollapsibleState.Collapsed;
-    });
   }
 
   getTreeItem(element: TektonNode): TreeItem | Thenable<TreeItem> {

--- a/src/tekton/pipeline.ts
+++ b/src/tekton/pipeline.ts
@@ -9,7 +9,7 @@ import { MultiStepInput, InputStep } from '../util/MultiStepInput';
 import { Progress } from '../util/progress';
 import { QuickPickItem, window } from 'vscode';
 import * as cliInstance from '../cli';
-import { CliImpl } from '../cli';
+import { cli } from '../cli';
 import * as k8s from 'vscode-kubernetes-tools-api';
 import { TknPipelineResource, TknPipelineTrigger } from '../tekton';
 
@@ -263,7 +263,7 @@ export class Pipeline extends TektonItem {
   }
 
   static async showTektonOutput(): Promise<void> {
-    CliImpl.getInstance().showOutputChannel();
+    cli.showOutputChannel();
   }
 
   static async describe(pipeline: TektonNode): Promise<void> {

--- a/src/tekton/pipelinerun.ts
+++ b/src/tekton/pipelinerun.ts
@@ -10,30 +10,11 @@ import { Progress } from '../util/progress';
 
 export class PipelineRun extends TektonItem {
 
-  // TODO: keep track of CLI development for this implementation 
-  // https://github.com/tektoncd/cli/issues/13 and https://github.com/tektoncd/cli/issues/12
-  /*     static cancel(context: TektonNode): Promise<void> {
-        throw new Error("Method not implemented.");
-    } */
-
-  /*     static async restart(pipelinerun: TektonNode): Promise<void> {
-        const pipelinerun = await PipelineRun.getTektonCmdData(treeItem,
-            "From which project you want to describe PipelineRun",
-            "Select PipelineRun you want to describe");
-        if (pipelinerun) { PipelineRun.tkn.executeInTerminal(Command.startPipeline(pipelinerun.getName(), undefined, undefined)); }
-    } */
-
   static async describe(pipelinerun: TektonNode): Promise<void> {
-    /*         const pipelinerun = await PipelineRun.getTektonCmdData(treeItem,
-            "From which project you want to describe PipelineRun",
-            "Select PipelineRun you want to describe"); */
     if (pipelinerun) { PipelineRun.tkn.executeInTerminal(Command.describePipelineRuns(pipelinerun.getName())); }
   }
 
   static async list(pipelinerun: TektonNode): Promise<void> {
-    /*         const pipelinerun = await PipelineRun.getTektonCmdData(treeItem,
-            "From which project you want to describe PipelineRun",
-            "Select PipelineRun you want to describe"); */
     if (pipelinerun) { PipelineRun.tkn.executeInTerminal(Command.listPipelineRunsInTerminal(pipelinerun.getName())); }
   }
 

--- a/src/tekton/tektonitem.ts
+++ b/src/tekton/tektonitem.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { Tkn, TknImpl, TektonNode } from '../tkn';
+import { Tkn, tkn as tknImpl, TektonNode } from '../tkn';
 import { PipelineExplorer, pipelineExplorer } from '../pipeline/pipelineExplorer';
 import { workspace, window } from 'vscode';
 import { kubefsUri } from '../util/tektonresources.virtualfs';
@@ -18,7 +18,7 @@ const errorMessage = {
 };
 
 export abstract class TektonItem {
-  protected static readonly tkn: Tkn = TknImpl.Instance;
+  protected static readonly tkn: Tkn = tknImpl;
   protected static readonly explorer: PipelineExplorer = pipelineExplorer;
 
   static validateUniqueName(data: Array<TektonNode>, value: string): string {
@@ -51,7 +51,7 @@ export abstract class TektonItem {
   }
 
   static async getTaskRunNames(taskrun: TektonNode): Promise<TektonNode[]> {
-    const taskrunList: Array<TektonNode> = await TektonItem.tkn.getTaskRuns(taskrun);
+    const taskrunList: Array<TektonNode> = await TektonItem.tkn.getTaskRunsForPipelineRun(taskrun);
     if (taskrunList.length === 0) { throw Error(errorMessage.TaskRun); }
     return taskrunList;
   }

--- a/src/tkn.ts
+++ b/src/tkn.ts
@@ -464,7 +464,7 @@ type PipelineTaskRunData = {
       'tekton.dev/pipelineRun': string;
     };
   };
-  status: {
+  status?: {
     completionTime: string;
     conditions: [{
       status: string;
@@ -487,18 +487,9 @@ export class TaskRun extends TektonNodeImpl {
     tkn: Tkn,
     item: PipelineTaskRunData) {
     super(parent, name, ContextType.TASKRUN, tkn, TreeItemCollapsibleState.None, item.metadata.creationTimestamp, item.status ? item.status.conditions[0].status : '');
-    // destructuring assignment to save only required data from 
-    ({
-      metadata: {
-        creationTimestamp: this.started,
-        labels: {
-          'tekton.dev/pipelineTask': this.shortName
-        }
-      }, status: {
-        completionTime: this.finished
-      }
-    } = item);
-
+    this.started = item.metadata.creationTimestamp;
+    this.shortName = item.metadata.labels['tekton.dev/pipelineTask'];
+    this.finished = item.status?.completionTime;
   }
 
   get label(): string {
@@ -534,15 +525,9 @@ export class PipelineRun extends TektonNodeImpl {
     tkn: Tkn,
     item: PipelineRunData, collapsibleState: TreeItemCollapsibleState) {
     super(parent, name, ContextType.PIPELINERUN, tkn, collapsibleState, item.metadata.creationTimestamp, item.status ? item.status.conditions[0].status : '');
-    // destructuring assignment to save only required data from
-    ({
-      metadata: {
-        creationTimestamp: this.started,
-        generateName: this.generateName
-      }, status: {
-        completionTime: this.finished
-      }
-    } = item);
+    this.started = item.metadata.creationTimestamp;
+    this.generateName = item.metadata.generateName;
+    this.finished = item.status?.completionTime;
   }
 
   get label(): string {

--- a/src/tkn.ts
+++ b/src/tkn.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
 
-import { CliCommand, CliExitData, Cli, CliImpl, createCliCommand, cliCommandToString } from './cli';
+import { CliCommand, CliExitData, cli, createCliCommand, cliCommandToString } from './cli';
 import { ProviderResult, TreeItemCollapsibleState, Terminal, Uri, workspace, TreeItem } from 'vscode';
 import { WindowUtil } from './util/windowUtils';
 import * as path from 'path';
@@ -106,8 +106,8 @@ export function newK8sCommand(...k8sArguments): CliCommand {
 
 export class Command {
   @verbose
-  static listTaskRunsforTasks(task: string): CliCommand {
-    return newTknCommand('taskrun', 'list', task, '-o', 'json');
+  static listTaskRunsForTasks(task: string): CliCommand {
+    return newK8sCommand('get', 'taskrun', '-l', `tekton.dev/task=${task}`, '-o', 'json');
   }
 
   @verbose
@@ -146,19 +146,19 @@ export class Command {
   }
   @verbose
   static listPipelineResources(): CliCommand {
-    return newTknCommand('resource', 'list', '-o', 'json');
+    return newK8sCommand('get', 'pipelineresources', '-o', 'json');
   }
   @verbose
   static listTriggerTemplates(): CliCommand {
-    return newTknCommand('triggertemplates', 'list', '-o', 'json');
+    return newK8sCommand('get', 'triggertemplates', '-o', 'json');
   }
   @verbose
   static listTriggerBinding(): CliCommand {
-    return newTknCommand('triggerbinding', 'list', '-o', 'json');
+    return newK8sCommand('get', 'triggerbinding', '-o', 'json');
   }
   @verbose
   static listEventListener(): CliCommand {
-    return newTknCommand('eventlistener', 'list', '-o', 'json');
+    return newK8sCommand('get', 'eventlistener', '-o', 'json');
   }
   static deleteTriggerTemplate(name: string): CliCommand {
     return newTknCommand('triggertemplate', 'delete', name, '-f');
@@ -183,7 +183,7 @@ export class Command {
   }
   @verbose
   static listPipelines(): CliCommand {
-    return newTknCommand('pipeline', 'list', '-o', 'json');
+    return newK8sCommand('get', 'pipeline', '-o', 'json');
   }
   @verbose
   static listPipelinesInTerminal(name: string): CliCommand {
@@ -195,7 +195,7 @@ export class Command {
   }
   @verbose
   static listPipelineRuns(name: string): CliCommand {
-    return newTknCommand('pipelinerun', 'list', name, '-o', 'json');
+    return newK8sCommand('get', 'pipelinerun', '-l', `tekton.dev/pipeline=${name}`, '-o', 'json');
   }
   @verbose
   static listPipelineRunsInTerminal(name: string): CliCommand {
@@ -219,7 +219,7 @@ export class Command {
   }
   @verbose
   static listTasks(namespace?: string): CliCommand {
-    return newTknCommand('task', 'list', ...(namespace ? ['-n', namespace] : ''), '-o', 'json');
+    return newK8sCommand('get', 'task', ...(namespace ? ['-n', namespace] : ''), '-o', 'json');
   }
   @verbose
   static listTasksinTerminal(namespace?: string): CliCommand {
@@ -229,6 +229,11 @@ export class Command {
   static listTaskRuns(namespace?: string): CliCommand {
     return newTknCommand('taskrun', 'list', ...(namespace ? ['-n', namespace] : ''), '-o', 'json');
   }
+
+  static listTaskRunsForPipelineRun(pipelineRunName: string): CliCommand {
+    return newK8sCommand('get', 'taskrun', '-l', `tekton.dev/pipelineRun=${pipelineRunName}`, '-o', 'json');
+  }
+
   @verbose
   static listTaskRunsInTerminal(namespace?: string): CliCommand {
     return newTknCommand('taskrun', 'list', ...(namespace ? ['-n', namespace] : ''));
@@ -239,7 +244,7 @@ export class Command {
   }
   @verbose
   static listClusterTasks(namespace?: string): CliCommand {
-    return newTknCommand('clustertask', 'list', ...(namespace ? ['-n', namespace] : ''), '-o', 'json');
+    return newK8sCommand('get', 'clustertask', ...(namespace ? ['-n', namespace] : ''), '-o', 'json');
   }
   static listClusterTasksinTerminal(namespace?: string): CliCommand {
     return newTknCommand('clustertask', 'list', ...(namespace ? ['-n', namespace] : ''));
@@ -269,20 +274,20 @@ export class Command {
   static createPipelineResource(yamlFile: string): CliCommand {
     return newTknCommand('resource', 'create', '-f', yamlFile);
   }
-  static tknStatus(): CliCommand {
+  static checkTekton(): CliCommand {
     return newK8sCommand('auth', 'can-i', 'create', 'pipeline.tekton.dev', '&&', 'kubectl', 'get', 'pipeline.tekton.dev');
   }
   static updateYaml(fsPath: string): CliCommand {
     return newTknCommand('apply', '-f', fsPath);
   }
   static listTaskRun(): CliCommand {
-    return newTknCommand('taskrun', 'list', '-o', 'json');
+    return newK8sCommand('get', 'taskrun', '-o', 'json');
   }
   static listConditions(): CliCommand {
     return newK8sCommand('get', 'conditions', '-o', 'json');
   }
   static listPipelineRun(): CliCommand {
-    return newTknCommand('pipelinerun', 'list', '-o', 'json');
+    return newK8sCommand('get', 'pipelinerun', '-o', 'json');
   }
 }
 
@@ -326,12 +331,12 @@ export class TektonNodeImpl implements TektonNode {
     pipelinerun: {
       icon: 'running.gif',
       tooltip: 'PipelineRun: {label}',
-      getChildren: () => this.tkn.getTaskRuns(this)
+      getChildren: () => this.tkn.getTaskRunsForPipelineRun(this)
     },
     task: {
       icon: 'T.svg',
       tooltip: 'Task: {label}',
-      getChildren: () => this.tkn.getTaskRunsforTasks(this)
+      getChildren: () => this.tkn.getTaskRunsForTasks(this)
     },
     taskrun: {
       icon: 'running.gif',
@@ -341,7 +346,7 @@ export class TektonNodeImpl implements TektonNode {
     clustertask: {
       icon: 'CT.svg',
       tooltip: 'Clustertask: {label}',
-      getChildren: () => this.tkn.getTaskRunsforTasks(this)
+      getChildren: () => this.tkn.getTaskRunsForTasks(this)
     },
     tknDown: {
       icon: 'tkn-down.png',
@@ -600,12 +605,12 @@ export interface Tkn {
   getPipelineResources(pipelineResources: TektonNode): Promise<TektonNode[]>;
   getTasks(task: TektonNode): Promise<TektonNode[]>;
   getRawTasks(): Promise<TknTask[]>;
-  getTaskRuns(taskRun: TektonNode): Promise<TektonNode[]>;
+  getTaskRunsForPipelineRun(taskRun: TektonNode): Promise<TektonNode[]>;
   getClusterTasks(clustertask: TektonNode): Promise<TektonNode[]>;
   getRawClusterTasks(): Promise<TknTask[]>;
   execute(command: CliCommand, cwd?: string, fail?: boolean): Promise<CliExitData>;
   executeInTerminal(command: CliCommand, cwd?: string): void;
-  getTaskRunsforTasks(task: TektonNode): Promise<TektonNode[]>;
+  getTaskRunsForTasks(task: TektonNode): Promise<TektonNode[]>;
   getTriggerTemplates(triggerTemplates: TektonNode): Promise<TektonNode[]>;
   getTriggerBinding(triggerBinding: TektonNode): Promise<TektonNode[]>;
   getEventListener(EventListener: TektonNode): Promise<TektonNode[]>;
@@ -613,10 +618,6 @@ export interface Tkn {
   getPipelineRunsList(pipelineRun: TektonNode): Promise<TektonNode[]>;
   getTaskRunList(taskRun: TektonNode): Promise<TektonNode[]>;
   clearCache?(): void;
-}
-
-export function getInstance(): Tkn {
-  return TknImpl.Instance;
 }
 
 function compareNodes(a, b): number {
@@ -643,43 +644,32 @@ function getStderrString(data: string | Error): string {
 export class TknImpl implements Tkn {
 
   public static ROOT: TektonNode = new TektonNodeImpl(undefined, 'root', undefined, undefined);
-  private cache: Map<TektonNode, TektonNode[]> = new Map();
-  private static cli: Cli = CliImpl.getInstance();
-  private static instance: Tkn;
+
   // Get page size from configuration, in case configuration is not present(dev mode) use hard coded value
   defaultPageSize: number = workspace.getConfiguration('vs-tekton').has('treePaginationLimit') ? workspace.getConfiguration('vs-tekton').get('treePaginationLimit') : 5;
 
-  public static get Instance(): Tkn {
-    if (!TknImpl.instance) {
-      TknImpl.instance = new TknImpl();
-    }
-    return TknImpl.instance;
-  }
-
   async getPipelineNodes(): Promise<TektonNode[]> {
     const result: CliExitData = await this.execute(
-      Command.tknStatus(), process.cwd(), false
+      Command.checkTekton(), process.cwd(), false
     );
     if (result.stdout.trim() === 'no') {
       const tknDownMsg = 'The current user doesn\'t have the privileges to interact with tekton resources.';
-      return [new TektonNodeImpl(null, tknDownMsg, ContextType.TKN_DOWN, TknImpl.instance, TreeItemCollapsibleState.None)];
+      return [new TektonNodeImpl(null, tknDownMsg, ContextType.TKN_DOWN, this, TreeItemCollapsibleState.None)];
     }
     if (result.error && getStderrString(result.error).indexOf('the server doesn\'t have a resource type "pipeline"') > -1) {
       const tknDownMsg = 'Please install the OpenShift Pipelines Operator.';
-      return [new TektonNodeImpl(null, tknDownMsg, ContextType.TKN_DOWN, TknImpl.instance, TreeItemCollapsibleState.None)];
+      return [new TektonNodeImpl(null, tknDownMsg, ContextType.TKN_DOWN, this, TreeItemCollapsibleState.None)];
     }
     const serverCheck = RegExp('Unable to connect to the server');
     if (serverCheck.test(getStderrString(result.error))) {
       const loginError = 'Unable to connect to OpenShift cluster, is it down?';
-      return [new TektonNodeImpl(null, loginError, ContextType.TKN_DOWN, TknImpl.instance, TreeItemCollapsibleState.None)];
+      return [new TektonNodeImpl(null, loginError, ContextType.TKN_DOWN, this, TreeItemCollapsibleState.None)];
     }
-    if (!this.cache.has(TknImpl.ROOT)) {
-      this.cache.set(TknImpl.ROOT, await this._getPipelineNodes());
-    }
-    return this.cache.get(TknImpl.ROOT);
+
+    return this._getPipelineNodes();
   }
 
-  public async _getPipelineNodes(): Promise<TektonNode[]> {
+  public _getPipelineNodes(): TektonNode[] {
     const pipelineTree: TektonNode[] = [];
     const pipelineNode = new TektonNodeImpl(TknImpl.ROOT, 'Pipelines', ContextType.PIPELINENODE, this, TreeItemCollapsibleState.Collapsed);
     const pipelineRunNode = new TektonNodeImpl(TknImpl.ROOT, 'PipelineRuns', ContextType.PIPELINERUNNODE, this, TreeItemCollapsibleState.Collapsed);
@@ -692,29 +682,21 @@ export class TknImpl implements Tkn {
     const eventListenerNode = new TektonNodeImpl(TknImpl.ROOT, 'EventListener', ContextType.EVENTLISTENERNODE, this, TreeItemCollapsibleState.Collapsed);
     const conditionsNode = new TektonNodeImpl(TknImpl.ROOT, 'Conditions', ContextType.CONDITIONSNODE, this, TreeItemCollapsibleState.Collapsed);
     pipelineTree.push(pipelineNode, pipelineRunNode, taskNode, clustertaskNode, taskRunNode, pipelineResourceNode, triggerTemplatesNode, triggerBindingNode, eventListenerNode, conditionsNode);
-    this.cache.set(pipelineNode, await this.getPipelines(pipelineNode));
-    this.cache.set(pipelineRunNode, await this.getPipelineRunsList(pipelineRunNode));
-    this.cache.set(taskNode, await this.getTasks(taskNode));
-    this.cache.set(clustertaskNode, await this.getClusterTasks(clustertaskNode));
-    this.cache.set(taskRunNode, await this.getTaskRunList(taskRunNode));
-    this.cache.set(pipelineResourceNode, await this.getPipelineResources(pipelineResourceNode));
-    this.cache.set(triggerTemplatesNode, await this.getTriggerTemplates(triggerTemplatesNode));
-    this.cache.set(triggerBindingNode, await this.getTriggerBinding(eventListenerNode));
-    this.cache.set(eventListenerNode, await this.getEventListener(eventListenerNode));
-    this.cache.set(conditionsNode, await this.getConditions(conditionsNode));
     return pipelineTree;
-
   }
 
-  async refreshPipelineRun(pipelineName: string): Promise<void> {
-    await kubectl.watchPipelineRun(pipelineName);
-    pipelineExplorer.refresh();
+  async refreshPipelineRun(pipeline: TektonNode): Promise<void> {
+    await kubectl.watchPipelineRun(pipeline.getName(), () => {
+      pipelineExplorer.refresh(pipeline);
+    });
+
+    pipelineExplorer.refresh(pipeline.getParent());
   }
 
   async getPipelineStatus(listOfPipelineRuns: TektonNode[]): Promise<void> {
     for (const pipelineRun of listOfPipelineRuns) {
       if (pipelineRun.state === 'Unknown') {
-        this.refreshPipelineRun(pipelineRun.getName());
+        this.refreshPipelineRun(pipelineRun);
       }
     }
   }
@@ -761,11 +743,9 @@ export class TknImpl implements Tkn {
     if (!pipeline.visibleChildren) {
       pipeline.visibleChildren = this.defaultPageSize;
     }
-    let pipelineRuns: TektonNode[] = this.cache.get(pipeline);
-    if (!pipelineRuns) {
-      pipelineRuns = await this._getPipelineRuns(pipeline);
-      this.cache.set(pipeline, pipelineRuns);
-    }
+
+    const pipelineRuns = await this._getPipelineRuns(pipeline);
+
     this.getPipelineStatus(pipelineRuns);
     return this.limitView(pipeline, pipelineRuns);
   }
@@ -786,22 +766,16 @@ export class TknImpl implements Tkn {
     }
 
     return data
-      .filter((value) => value.spec.pipelineRef.name === pipeline.getName())
       .map((value) => new PipelineRun(pipeline, value.metadata.name, this, value, TreeItemCollapsibleState.Expanded))
       .sort(compareTimeNewestFirst);
   }
 
-  public async getTaskRunsforTasks(task: TektonNode): Promise<TektonNode[]> {
-    let taskruns: TektonNode[] = this.cache.get(task);
-    if (!taskruns) {
-      taskruns = await this._getTaskRunsforTasks(task);
-      this.cache.set(task, taskruns);
-    }
-    return taskruns;
+  async getTaskRunsForTasks(task: TektonNode): Promise<TektonNode[]> {
+    return this._getTaskRunsForTasks(task);
   }
 
-  async _getTaskRunsforTasks(task: TektonNode): Promise<TektonNode[]> {
-    const result = await this.execute(Command.listTaskRunsforTasks(task.getName()));
+  async _getTaskRunsForTasks(task: TektonNode): Promise<TektonNode[]> {
+    const result = await this.execute(Command.listTaskRunsForTasks(task.getName()));
     if (result.error) {
       console.log(result + ' Std.err when processing taskruns for ' + task.getName());
       return [new TektonNodeImpl(task, getStderrString(result.error), ContextType.TASKRUN, this, TreeItemCollapsibleState.None)];
@@ -813,7 +787,6 @@ export class TknImpl implements Tkn {
     } catch (ignore) {
     }
     return data
-      .filter((value) => value.spec.taskRef.name === task.getName())
       .map((value) => new TaskRun(task, value.metadata.name, this, value))
       .sort(compareTimeNewestFirst);
   }
@@ -843,21 +816,18 @@ export class TknImpl implements Tkn {
     return data.map((value) => new TaskRun(taskRun, value.metadata.name, this, value));
   }
 
-  async getTaskRuns(pipelineRun: TektonNode): Promise<TektonNode[]> {
+  async getTaskRunsForPipelineRun(pipelineRun: TektonNode): Promise<TektonNode[]> {
     if (!pipelineRun.visibleChildren) {
       pipelineRun.visibleChildren = this.defaultPageSize;
     }
 
-    let taskRuns: TektonNode[] = this.cache.get(pipelineRun);
-    if (!taskRuns) {
-      taskRuns = await this._getTaskRuns(pipelineRun);
-      this.cache.set(pipelineRun, taskRuns);
-    }
+    const taskRuns = await this._getTaskRunsForPipelineRun(pipelineRun);
+
     return this.limitView(pipelineRun, taskRuns);
   }
 
-  async _getTaskRuns(pipelinerun: TektonNode): Promise<TektonNode[]> {
-    const result = await this.execute(Command.listTaskRuns());
+  async _getTaskRunsForPipelineRun(pipelinerun: TektonNode): Promise<TektonNode[]> {
+    const result = await this.execute(Command.listTaskRunsForPipelineRun(pipelinerun.getName()));
     if (result.error) {
       console.log(result + ' Std.err when processing pipelines');
       return [new TektonNodeImpl(pipelinerun, getStderrString(result.error), ContextType.TASKRUN, this, TreeItemCollapsibleState.Expanded)];
@@ -870,13 +840,12 @@ export class TknImpl implements Tkn {
     }
 
     return data
-      .filter((value) => value.metadata.labels['tekton.dev/pipelineRun'] === pipelinerun.getName())
       .map((value) => new TaskRun(pipelinerun, value.metadata.name, this, value))
       .sort(compareTimeNewestFirst);
   }
 
   async getPipelines(pipeline: TektonNode): Promise<TektonNode[]> {
-    return (await this._getPipelines(pipeline));
+    return this._getPipelines(pipeline);
   }
 
   async _getPipelines(pipeline: TektonNode): Promise<TektonNode[]> {
@@ -898,7 +867,7 @@ export class TknImpl implements Tkn {
   }
 
   async getPipelineResources(pipelineResources: TektonNode): Promise<TektonNode[]> {
-    return (await this._getPipelineResources(pipelineResources));
+    return this._getPipelineResources(pipelineResources);
   }
 
   private async _getPipelineResources(pipelineResource: TektonNode): Promise<TektonNode[]> {
@@ -918,7 +887,7 @@ export class TknImpl implements Tkn {
   }
 
   async getConditions(conditionsNode: TektonNode): Promise<TektonNode[]> {
-    return (await this._getConditions(conditionsNode, Command.listConditions(), ContextType.CONDITIONS));
+    return this._getConditions(conditionsNode, Command.listConditions(), ContextType.CONDITIONS);
   }
 
   private async _getConditions(conditionResource: TektonNode, command: CliCommand, conditionContextType: ContextType): Promise<TektonNode[]> {
@@ -938,15 +907,15 @@ export class TknImpl implements Tkn {
   }
 
   async getTriggerTemplates(triggerTemplatesNode: TektonNode): Promise<TektonNode[]> {
-    return (await this._getTriggerResource(triggerTemplatesNode, Command.listTriggerTemplates(), ContextType.TRIGGERTEMPLATES));
+    return this._getTriggerResource(triggerTemplatesNode, Command.listTriggerTemplates(), ContextType.TRIGGERTEMPLATES);
   }
 
   async getTriggerBinding(triggerBindingNode: TektonNode): Promise<TektonNode[]> {
-    return (await this._getTriggerResource(triggerBindingNode, Command.listTriggerBinding(), ContextType.TRIGGERBINDING));
+    return this._getTriggerResource(triggerBindingNode, Command.listTriggerBinding(), ContextType.TRIGGERBINDING);
   }
 
   async getEventListener(eventListenerNode: TektonNode): Promise<TektonNode[]> {
-    return (await this._getTriggerResource(eventListenerNode, Command.listEventListener(), ContextType.EVENTLISTENER));
+    return this._getTriggerResource(eventListenerNode, Command.listEventListener(), ContextType.EVENTLISTENER);
   }
 
   private async _getTriggerResource(trigerResource: TektonNode, command: CliCommand, triggerContextType: ContextType): Promise<TektonNode[]> {
@@ -966,7 +935,7 @@ export class TknImpl implements Tkn {
   }
 
   public async getTasks(task: TektonNode): Promise<TektonNode[]> {
-    return (await this._getTasks(task));
+    return this._getTasks(task);
   }
 
   async _getTasks(task: TektonNode): Promise<TektonNode[]> {
@@ -1003,7 +972,7 @@ export class TknImpl implements Tkn {
   }
 
   async getClusterTasks(clustertask: TektonNode): Promise<TektonNode[]> {
-    return (await this._getClusterTasks(clustertask));
+    return this._getClusterTasks(clustertask);
   }
 
   async _getClusterTasks(clustertask: TektonNode): Promise<TektonNode[]> {
@@ -1055,7 +1024,7 @@ export class TknImpl implements Tkn {
     await this.executeInTerminal(Command.restartPipeline(pipeline.getName()));
   }
 
-  public async executeInTerminal(command: CliCommand, cwd: string = process.cwd(), name = 'Tekton'): Promise<void> {
+  async executeInTerminal(command: CliCommand, cwd: string = process.cwd(), name = 'Tekton'): Promise<void> {
     let toolLocation = await ToolsConfig.detectOrDownload();
     if (toolLocation) {
       toolLocation = path.dirname(toolLocation);
@@ -1065,21 +1034,20 @@ export class TknImpl implements Tkn {
     terminal.show();
   }
 
-  public async execute(command: CliCommand, cwd?: string, fail = true): Promise<CliExitData> {
-    const toolLocation = await ToolsConfig.detectOrDownload();
-    if (toolLocation) {
-      command.cliCommand = command.cliCommand.replace('tkn', `"${toolLocation}"`).replace(new RegExp('&& tkn', 'g'), `&& "${toolLocation}"`);
+  async execute(command: CliCommand, cwd?: string, fail = true): Promise<CliExitData> {
+    if (command.cliCommand.indexOf('tkn') >= 0) {
+      const toolLocation = await ToolsConfig.detectOrDownload();
+      if (toolLocation) {
+        // eslint-disable-next-line require-atomic-updates
+        command.cliCommand = command.cliCommand.replace('tkn', `"${toolLocation}"`).replace(new RegExp('&& tkn', 'g'), `&& "${toolLocation}"`);
+      }
     }
 
-
-    return TknImpl.cli.execute(command, cwd ? { cwd } : {})
+    return cli.execute(command, cwd ? { cwd } : {})
       .then(async (result) => result.error && fail ? Promise.reject(result.error) : result)
       .catch((err) => fail ? Promise.reject(err) : Promise.resolve({ error: null, stdout: '', stderr: '' }));
   }
 
-  clearCache(): void {
-    this.cache.clear();
-  }
 }
 
-export const tknInstance = new TknImpl();
+export const tkn = new TknImpl();

--- a/src/tkn.ts
+++ b/src/tkn.ts
@@ -676,7 +676,7 @@ export class TknImpl implements Tkn {
     await kubectl.watchPipelineRun(pipeline.getName(), () => {
       pipelineExplorer.refresh(pipeline);
       for (const item of TknImpl.ROOT.getChildren() as TektonNodeImpl[]) {
-        if (nodeToRefresh.includes(item.getName()) && item.collapsibleState === TreeItemCollapsibleState.Expanded) {
+        if (nodeToRefresh.includes(item.getName())) {
           pipelineExplorer.refresh(item);
         }
       }

--- a/src/tkn.ts
+++ b/src/tkn.ts
@@ -690,7 +690,7 @@ export class TknImpl implements Tkn {
       pipelineExplorer.refresh(pipeline);
     });
 
-    pipelineExplorer.refresh(pipeline.getParent());
+    pipelineExplorer.refresh(); // refresh all tree
   }
 
   async getPipelineStatus(listOfPipelineRuns: TektonNode[]): Promise<void> {
@@ -736,7 +736,7 @@ export class TknImpl implements Tkn {
     } catch (ignore) {
     }
 
-    return data.map((value) => new PipelineRun(pipelineRun, value.metadata.name, this, value, TreeItemCollapsibleState.None));
+    return data.map((value) => new PipelineRun(pipelineRun, value.metadata.name, this, value, TreeItemCollapsibleState.None)).sort(compareTimeNewestFirst);
   }
 
   async getPipelineRuns(pipeline: TektonNode): Promise<TektonNode[]> {
@@ -813,7 +813,7 @@ export class TknImpl implements Tkn {
     } catch (ignore) {
     }
 
-    return data.map((value) => new TaskRun(taskRun, value.metadata.name, this, value));
+    return data.map((value) => new TaskRun(taskRun, value.metadata.name, this, value)).sort(compareTimeNewestFirst);
   }
 
   async getTaskRunsForPipelineRun(pipelineRun: TektonNode): Promise<TektonNode[]> {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -12,7 +12,7 @@ import open = require('open');
 import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fsex from 'fs-extra';
-import { createCliCommand, CliImpl } from './cli';
+import { createCliCommand, cli } from './cli';
 import semver = require('semver');
 import configData = require('./tools.json');
 
@@ -49,9 +49,9 @@ export class ToolsConfig {
       toolLocation = await ToolsConfig.selectTool(toolLocations, ToolsConfig.tool['tkn'].versionRange);
       const downloadVersion = `Download ${ToolsConfig.tool['tkn'].version}`;
 
-      const currentVersion = await ToolsConfig.getVersion(toolLocation);
       if (toolLocation) {
-        if(!semver.satisfies(currentVersion, ToolsConfig.tool['tkn'].versionRange)) {
+        const currentVersion = await ToolsConfig.getVersion(toolLocation);
+        if (!semver.satisfies(currentVersion, ToolsConfig.tool['tkn'].versionRange)) {
           response = await vscode.window.showWarningMessage(`Detected unsupported tkn version: ${currentVersion}. Supported tkn version: ${ToolsConfig.tool['tkn'].versionRangeLabel}.`, downloadVersion, 'Cancel');
         }
       }
@@ -121,7 +121,7 @@ export class ToolsConfig {
     let detectedVersion: string;
     if (await fsex.pathExists(location)) {
       const version = new RegExp('^Client version:\\s[v]?([0-9]+\\.[0-9]+\\.[0-9]+)$');
-      const result = await CliImpl.getInstance().execute(createCliCommand(`"${location}"`, 'version'));
+      const result = await cli.execute(createCliCommand(`"${location}"`, 'version'));
       if (result.stdout) {
         const toolVersion: string[] = result.stdout.trim().split('\n').filter((value) => {
           return value.match(version);

--- a/src/util/progress.ts
+++ b/src/util/progress.ts
@@ -52,7 +52,7 @@ export class Progress {
         location: vscode.ProgressLocation.Notification,
         title
       }, async () => {
-        const result = await tknctl.getInstance().execute(cmd, process.cwd(), false);
+        const result = await tknctl.tkn.execute(cmd, process.cwd(), false);
         result.error ? reject(result.error) : resolve();
       });
     });

--- a/src/util/tektonresources.virtualfs.ts
+++ b/src/util/tektonresources.virtualfs.ts
@@ -12,7 +12,7 @@ import * as path from 'path';
 import * as os from 'os'
 import * as querystring from 'querystring';
 import { FileSystemProvider, Uri, EventEmitter, FileChangeEvent, Event, Disposable, FileStat, FileType, window, workspace, commands } from 'vscode';
-import { Cli, CliImpl, CliExitData } from '../cli';
+import { cli, CliExitData } from '../cli';
 import { Command } from '../tkn';
 import * as k8s from 'vscode-kubernetes-tools-api';
 import { TektonItem } from '../tekton/tektonitem';
@@ -31,7 +31,6 @@ export function kubefsUri(value: string, outputFormat: string): Uri {
 export class TektonResourceVirtualFileSystemProvider implements FileSystemProvider {
 
   private readonly onDidChangeFileEmitter: EventEmitter<FileChangeEvent[]> = new EventEmitter<FileChangeEvent[]>();
-  private static cli: Cli = CliImpl.getInstance();
 
   onDidChangeFile: Event<FileChangeEvent[]> = this.onDidChangeFileEmitter.event;
 
@@ -143,7 +142,7 @@ export class TektonResourceVirtualFileSystemProvider implements FileSystemProvid
     if (kubectl.available) {
       return await kubectl.api.invokeCommand(`apply -f ${fsPath}`);
     }
-    return await TektonResourceVirtualFileSystemProvider.cli.execute(Command.updateYaml(fsPath));
+    return await cli.execute(Command.updateYaml(fsPath));
   }
 
   delete(): void | Thenable<void> {

--- a/src/yaml-support/tkn-tasks-provider.ts
+++ b/src/yaml-support/tkn-tasks-provider.ts
@@ -2,7 +2,7 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
-import { TknImpl } from '../tkn';
+import { tkn } from '../tkn';
 import { TknTask } from '../tekton';
 
 export interface Snippet {
@@ -57,7 +57,6 @@ interface Param {
 }
 
 export async function getTknTasksSnippets(): Promise<Snippet[]> {
-  const tkn = TknImpl.Instance;
   const [rawClusterTasks, rawTasks] = await Promise.all([tkn.getRawClusterTasks(), tkn.getRawTasks()]);
 
   const allRawTasks = rawClusterTasks.concat(rawTasks);

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -8,7 +8,7 @@
 import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 import * as sinon from 'sinon';
-import { createCliCommand, cliCommandToString, CliImpl } from '../src/cli';
+import { createCliCommand, cliCommandToString, cli } from '../src/cli';
 import * as childProcess from 'child_process';
 import * as events from 'events';
 import * as stream from 'stream';
@@ -20,7 +20,6 @@ suite('Cli', () => {
   const sandbox = sinon.createSandbox();
   let spawnStub: sinon.SinonStub;
   let procMock: childProcess.ChildProcess;
-  const cli = CliImpl.getInstance();
   const command = createCliCommand('command');
   const options: childProcess.SpawnOptions = { cwd: 'cwd', shell: true, windowsHide: true };
   const stdout = 'Standard output';

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -21,7 +21,7 @@ import { Pipeline } from '../src/tekton/pipeline';
 import { Task } from '../src/tekton/task';
 import { ClusterTask } from '../src/tekton/clustertask';
 import packagejson = require('../package.json');
-import { TknImpl, TektonNodeImpl, ContextType } from '../src/tkn';
+import { TknImpl, tkn, TektonNodeImpl, ContextType } from '../src/tkn';
 import { PipelineExplorer } from '../src/pipeline/pipelineExplorer';
 import { TektonItem } from '../src/tekton/tektonitem';
 
@@ -30,14 +30,14 @@ chai.use(sinonChai);
 
 suite('Tekton Pipeline Extension', () => {
   const sandbox = sinon.createSandbox();
-  const pipelineNode = new TektonNodeImpl(TknImpl.ROOT, 'Pipelines', ContextType.PIPELINENODE, TknImpl.Instance, vscode.TreeItemCollapsibleState.Collapsed);
-  const taskNode = new TektonNodeImpl(TknImpl.ROOT, 'Tasks', ContextType.TASKNODE, TknImpl.Instance, vscode.TreeItemCollapsibleState.Collapsed);
-  const clustertaskNode = new TektonNodeImpl(TknImpl.ROOT, 'Clustertasks', ContextType.CLUSTERTASKNODE, TknImpl.Instance, vscode.TreeItemCollapsibleState.Collapsed);
-  const pipelineItem = new TektonNodeImpl(pipelineNode, 'test-pipeline', ContextType.PIPELINE, TknImpl.Instance, vscode.TreeItemCollapsibleState.Collapsed);
-  const pipelinerunItem = new TektonNodeImpl(pipelineItem, 'test-pipeline-1', ContextType.PIPELINERUN, TknImpl.Instance, vscode.TreeItemCollapsibleState.Collapsed, '2019-07-25T12:00:00Z', 'True');
-  const taskrunItem = new TektonNodeImpl(pipelinerunItem, 'test-taskrun-1', ContextType.TASKRUN, TknImpl.Instance, vscode.TreeItemCollapsibleState.Collapsed, '2019-07-25T12:03:00Z', 'True');
-  const taskItem = new TektonNodeImpl(taskNode, 'test-tasks', ContextType.TASK, TknImpl.Instance, vscode.TreeItemCollapsibleState.None);
-  const clustertaskItem = new TektonNodeImpl(clustertaskNode, 'test-Clustertask', ContextType.CLUSTERTASK, TknImpl.Instance, vscode.TreeItemCollapsibleState.None);
+  const pipelineNode = new TektonNodeImpl(TknImpl.ROOT, 'Pipelines', ContextType.PIPELINENODE, tkn, vscode.TreeItemCollapsibleState.Collapsed);
+  const taskNode = new TektonNodeImpl(TknImpl.ROOT, 'Tasks', ContextType.TASKNODE, tkn, vscode.TreeItemCollapsibleState.Collapsed);
+  const clustertaskNode = new TektonNodeImpl(TknImpl.ROOT, 'Clustertasks', ContextType.CLUSTERTASKNODE, tkn, vscode.TreeItemCollapsibleState.Collapsed);
+  const pipelineItem = new TektonNodeImpl(pipelineNode, 'test-pipeline', ContextType.PIPELINE, tkn, vscode.TreeItemCollapsibleState.Collapsed);
+  const pipelinerunItem = new TektonNodeImpl(pipelineItem, 'test-pipeline-1', ContextType.PIPELINERUN, tkn, vscode.TreeItemCollapsibleState.Collapsed, '2019-07-25T12:00:00Z', 'True');
+  const taskrunItem = new TektonNodeImpl(pipelinerunItem, 'test-taskrun-1', ContextType.TASKRUN, tkn, vscode.TreeItemCollapsibleState.Collapsed, '2019-07-25T12:03:00Z', 'True');
+  const taskItem = new TektonNodeImpl(taskNode, 'test-tasks', ContextType.TASK, tkn, vscode.TreeItemCollapsibleState.None);
+  const clustertaskItem = new TektonNodeImpl(clustertaskNode, 'test-Clustertask', ContextType.CLUSTERTASK, tkn, vscode.TreeItemCollapsibleState.None);
 
   setup(async () => {
 
@@ -54,12 +54,11 @@ suite('Tekton Pipeline Extension', () => {
     sandbox.stub(TknImpl.prototype, '_getTasks').resolves([taskItem]);
     sandbox.stub(TknImpl.prototype, '_getClusterTasks').resolves([clustertaskItem]);
     sandbox.stub(TknImpl.prototype, '_getPipelineRuns').resolves([pipelinerunItem]);
-    sandbox.stub(TknImpl.prototype, '_getTaskRuns').resolves([taskrunItem]);
+    sandbox.stub(TknImpl.prototype, '_getTaskRunsForPipelineRun').resolves([taskrunItem]);
   });
 
   teardown(() => {
     sandbox.restore();
-    TknImpl.Instance.clearCache();
   });
 
   test('Extension should be present', () => {
@@ -96,19 +95,19 @@ suite('Tekton Pipeline Extension', () => {
 
   test('should load pipeline, task, clustertasks and pipelineresources', async () => {
     sandbox.stub(TknImpl.prototype, 'execute').resolves({ error: '', stdout: '' });
-    const pipelinenodes = await TknImpl.Instance.getPipelineNodes();
+    const pipelinenodes = await tkn.getPipelineNodes();
     expect(pipelinenodes.length).equals(10);
   });
 
   test('should load pipelineruns from pipeline folder', async () => {
     sandbox.stub(TknImpl.prototype, 'execute').resolves({ error: undefined, stdout: '' });
-    const pipelinerun = await TknImpl.Instance.getPipelineRuns(pipelineItem);
+    const pipelinerun = await tkn.getPipelineRuns(pipelineItem);
     expect(pipelinerun.length).is.equals(1);
   });
 
   test('should load taskruns from pipelinerun folder', async () => {
     sandbox.stub(TknImpl.prototype, 'execute').resolves({ error: undefined, stdout: '' });
-    const taskrun = await TknImpl.Instance.getTaskRuns(pipelinerunItem);
+    const taskrun = await tkn.getTaskRunsForPipelineRun(pipelinerunItem);
     expect(taskrun.length).is.equals(1);
   });
 

--- a/test/kubernetes.test.ts
+++ b/test/kubernetes.test.ts
@@ -17,7 +17,7 @@ suite('Kubernetos', () => {
   suite('K8s commands', () => {
     let executeInTerminalStub: sinon.SinonStub;
     setup(() => {
-      executeInTerminalStub = sandbox.stub(tkn.tknInstance, 'executeInTerminal');
+      executeInTerminalStub = sandbox.stub(tkn.tkn, 'executeInTerminal');
     });
 
     teardown(() => {

--- a/test/tekton/taskrun.test.ts
+++ b/test/tekton/taskrun.test.ts
@@ -29,7 +29,7 @@ suite('Tekton/TaskRun', () => {
 
   setup(() => {
     execStub = sandbox.stub(TknImpl.prototype, 'execute').resolves({ error: null, stdout: '', stderr: '' });
-    sandbox.stub(TknImpl.prototype, 'getTaskRuns').resolves([taskrunItem]);
+    sandbox.stub(TknImpl.prototype, 'getTaskRunsForPipelineRun').resolves([taskrunItem]);
     getPipelineRunNamesStub = sandbox.stub(TektonItem, 'getPipelinerunNames').resolves([pipelinerunItem]);
     sandbox.stub(vscode.window, 'showInputBox').resolves();
   });
@@ -99,7 +99,7 @@ suite('Tekton/TaskRun', () => {
 
         test('calls the appropriate error message when no project found', async () => {
           getTaskRunsStub.restore();
-          sandbox.stub(TknImpl.prototype, 'getTaskRunsforTasks').resolves([]);
+          sandbox.stub(TknImpl.prototype, 'getTaskRunsForTasks').resolves([]);
           try {
             await TaskRun.listFromTask(null);
           } catch (err) {

--- a/test/tekton/tektonitem.test.ts
+++ b/test/tekton/tektonitem.test.ts
@@ -152,14 +152,14 @@ suite('TektonItem', () => {
   suite('getTaskrunNames', () => {
 
     test('returns an array of taskrun names for the pipelinerun if there is at least one task', async () => {
-      sandbox.stub(TknImpl.prototype, 'getTaskRuns').resolves([taskrunItem]);
+      sandbox.stub(TknImpl.prototype, 'getTaskRunsForPipelineRun').resolves([taskrunItem]);
       const taskrunNames = await TektonItem.getTaskRunNames(pipelinerunItem);
       expect(taskrunNames[0].getName()).equals('taskrun');
 
     });
 
     test('throws error if there are no taskruns available', async () => {
-      sandbox.stub(TknImpl.prototype, 'getTaskRuns').resolves([]);
+      sandbox.stub(TknImpl.prototype, 'getTaskRunsForPipelineRun').resolves([]);
       try {
         await TektonItem.getTaskRunNames(pipelinerunItem);
       } catch (err) {

--- a/test/tkn.int.ts
+++ b/test/tkn.int.ts
@@ -11,7 +11,7 @@ import { TestItem } from './tekton/testTektonitem';
 import { Pipeline } from '../src/tekton/pipeline';
 
 suite('tkn integration', () => {
-  const tk: tkn.Tkn = tkn.getInstance();
+  const tk: tkn.Tkn = tkn.tkn;
   const pipelineItem = new TestItem(null, 'pipeline', tkn.ContextType.PIPELINE);
   const sb = sinon.createSandbox();
 

--- a/test/tkn.test.ts
+++ b/test/tkn.test.ts
@@ -25,14 +25,13 @@ chai.use(sinonChai);
 
 // This needs to be edited to actually make sense wrt Tasks/TaskRuns in particular and nesting of resources
 suite('tkn', () => {
-  const tknCli: tkn.Tkn = tkn.TknImpl.Instance;
+  const tknCli: tkn.Tkn = tkn.tkn;
   let startPipelineObj: StartPipelineObject;
   const sandbox = sinon.createSandbox();
   const errorMessage = 'Error';
 
   setup(() => {
     sandbox.stub(ToolsConfig, 'getVersion').resolves('0.2.0');
-    tknCli.clearCache();
   });
 
   teardown(() => {
@@ -911,7 +910,7 @@ suite('tkn', () => {
             }]
         })
       });
-      const result = await tknCli.getTaskRuns(pipelinerunItem);
+      const result = await tknCli.getTaskRunsForPipelineRun(pipelinerunItem);
 
       expect(result.length).equals(2);
       expect(result[0].getName()).equals('taskrun1');
@@ -970,19 +969,19 @@ suite('tkn', () => {
             }]
         })
       });
-      const result = await tknCli.getTaskRuns(pipelinerunItem);
-      expect(execStub).calledWith(tkn.Command.listTaskRuns());
+      const result = await tknCli.getTaskRunsForPipelineRun(pipelinerunItem);
+      expect(execStub).calledWith(tkn.Command.listTaskRunsForPipelineRun(pipelinerunItem.getName()));
       expect(result.length).equals(2);
       for (let i = 0; i < result.length; i++) {
         expect(result[i].getName()).equals(tknTaskRuns[i]);
       }
     });
 
-    test('getTaskruns returns an empty list if an error occurs', async () => {
-      sandbox.stub(tkn.TknImpl.prototype, 'getTaskRuns').resolves([]);
+    test('getTaskRunsForPipelineRun returns an empty list if an error occurs', async () => {
+      sandbox.stub(tkn.TknImpl.prototype, 'getTaskRunsForPipelineRun').resolves([]);
       execStub.onFirstCall().resolves({ error: undefined, stdout: '' });
       execStub.onSecondCall().rejects(errorMessage);
-      const result = await tknCli.getTaskRuns(pipelinerunItem);
+      const result = await tknCli.getTaskRunsForPipelineRun(pipelinerunItem);
 
       // tslint:disable-next-line: no-unused-expression
       expect(result).empty;
@@ -1042,7 +1041,7 @@ suite('tkn', () => {
             }]
         })
       });
-      const result = await tknCli.getTaskRunsforTasks(taskItem);
+      const result = await tknCli.getTaskRunsForTasks(taskItem);
 
       expect(result.length).equals(2);
       expect(result[0].getName()).equals('taskrun1');
@@ -1103,8 +1102,8 @@ suite('tkn', () => {
             }]
         })
       });
-      const result = await tknCli.getTaskRunsforTasks(taskItem);
-      expect(execStub).calledWith(tkn.Command.listTaskRunsforTasks(taskItem.getName()));
+      const result = await tknCli.getTaskRunsForTasks(taskItem);
+      expect(execStub).calledWith(tkn.Command.listTaskRunsForTasks(taskItem.getName()));
       expect(result.length).equals(2);
       for (let i = 0; i < result.length; i++) {
         expect(result[i].getName()).equals(tknTaskRuns[i]);
@@ -1112,10 +1111,10 @@ suite('tkn', () => {
     });
 
     test('getTaskrunsFromTasks returns an empty list if an error occurs', async () => {
-      sandbox.stub(tkn.TknImpl.prototype, 'getTaskRunsforTasks').resolves([]);
+      sandbox.stub(tkn.TknImpl.prototype, 'getTaskRunsForTasks').resolves([]);
       execStub.onFirstCall().resolves({ error: undefined, stdout: '' });
       execStub.onSecondCall().rejects(errorMessage);
-      const result = await tknCli.getTaskRunsforTasks(taskItem);
+      const result = await tknCli.getTaskRunsForTasks(taskItem);
 
       // tslint:disable-next-line: no-unused-expression
       expect(result).empty;
@@ -1175,7 +1174,7 @@ suite('tkn', () => {
             }]
         })
       });
-      const result = await tknCli.getTaskRunsforTasks(clustertaskItem);
+      const result = await tknCli.getTaskRunsForTasks(clustertaskItem);
 
       expect(result.length).equals(2);
       expect(result[0].getName()).equals('taskrun1');
@@ -1236,8 +1235,8 @@ suite('tkn', () => {
             }]
         })
       });
-      const result = await tknCli.getTaskRunsforTasks(clustertaskItem);
-      expect(execStub).calledWith(tkn.Command.listTaskRunsforTasks(clustertaskItem.getName()));
+      const result = await tknCli.getTaskRunsForTasks(clustertaskItem);
+      expect(execStub).calledWith(tkn.Command.listTaskRunsForTasks(clustertaskItem.getName()));
       expect(result.length).equals(2);
       for (let i = 0; i < result.length; i++) {
         expect(result[i].getName()).equals(tknTaskRuns[i]);
@@ -1245,7 +1244,7 @@ suite('tkn', () => {
     });
 
     test('getPipelineRunChildren returns taskruns for an pipelinerun', async () => {
-      sandbox.stub(tkn.TknImpl.prototype, 'getTaskRuns').resolves([taskrunItem]);
+      sandbox.stub(tkn.TknImpl.prototype, 'getTaskRunsForPipelineRun').resolves([taskrunItem]);
       execStub.onFirstCall().resolves({
         error: undefined, stdout: JSON.stringify({
           items: [
@@ -1265,7 +1264,7 @@ suite('tkn', () => {
       });
       execStub.onSecondCall().resolves({ error: undefined, stdout: 'serv' });
       //TODO: Probably need a get children here
-      const result = await tknCli.getTaskRuns(pipelinerunItem);
+      const result = await tknCli.getTaskRunsForPipelineRun(pipelinerunItem);
 
       expect(result[0].getName()).deep.equals('taskrun1');
     });

--- a/test/util/progress.test.ts
+++ b/test/util/progress.test.ts
@@ -10,7 +10,7 @@ import * as sinonChai from 'sinon-chai';
 import * as sinon from 'sinon';
 import { Progress } from '../../src/util/progress';
 import * as vscode from 'vscode';
-import { TknImpl } from '../../src/tkn';
+import { TknImpl, tkn } from '../../src/tkn';
 import { createCliCommand } from '../../src/cli';
 
 const expect = chai.expect;
@@ -35,7 +35,7 @@ suite('Progress Utility', () => {
 
   test('calls cli commands in sequence', async () => {
     execStub = sandbox.stub(TknImpl.prototype, 'execute').resolves({ error: undefined, stdout: '', stderr: '' });
-    await Progress.execWithProgress(options, steps, TknImpl.Instance);
+    await Progress.execWithProgress(options, steps, tkn);
 
     // tslint:disable-next-line: no-unused-expression
     expect(execStub).calledTwice;
@@ -46,7 +46,7 @@ suite('Progress Utility', () => {
   test('calls progress with given options', async () => {
     execStub = sandbox.stub(TknImpl.prototype, 'execute').resolves({ error: undefined, stdout: '', stderr: '' });
     const spy = sandbox.spy(vscode.window, 'withProgress');
-    await Progress.execWithProgress(options, steps, TknImpl.Instance);
+    await Progress.execWithProgress(options, steps, tkn);
 
     expect(spy).calledOnceWith(options, sinon.match.func);
   });
@@ -56,7 +56,7 @@ suite('Progress Utility', () => {
     execStub = sandbox.stub(TknImpl.prototype, 'execute').rejects(error);
     let e;
     try {
-      await Progress.execWithProgress(options, steps, TknImpl.Instance);
+      await Progress.execWithProgress(options, steps, tkn);
     } catch (err) {
       e = err;
       expect(err.message).equals(errorMessage);

--- a/test/yaml-support/tasks-provider.test.ts
+++ b/test/yaml-support/tasks-provider.test.ts
@@ -14,7 +14,7 @@ chai.use(sinonChai);
 suite('Task provider', () => {
   const sandbox = sinon.createSandbox();
   let execStub: sinon.SinonStub;
-  const tknCli: tkn.Tkn = tkn.TknImpl.Instance;
+  const tknCli: tkn.Tkn = tkn.tkn;
 
   setup(() => {
     execStub = sandbox.stub(tknCli, 'execute');


### PR DESCRIPTION
This PR increase Tekton tree loading speed. Also now Tekton tree use only `kubectl` to get data for nodes.
Also it add better update tree when pipelinerun is running.

Demo:
![ezgif com-video-to-gif (3)](https://user-images.githubusercontent.com/929743/79540201-66689f80-8090-11ea-9a1b-f67284e4a64e.gif)

Fix: #240
Fix: #239