### PR TITLE
Implement 'Go to Declaration' for pipeline yaml

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import { TriggerTemplate } from './tekton/triggertemplate';
 import { TriggerBinding } from './tekton/triggerbinding';
 import { EventListener } from './tekton/eventlistener';
 import { k8sCommands } from './kubernetes';
+import { initializeTknEditing } from './yaml-support/tkn-editing';
 
 export let contextGlobalState: vscode.ExtensionContext;
 let k8sExplorer: k8s.ClusterExplorerV1 | undefined = undefined;
@@ -115,6 +116,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   registerYamlSchemaSupport(context);
   registerPipelinePreviewContext();
+  initializeTknEditing(context);
 }
 
 async function isTekton(): Promise<boolean> {

--- a/src/util/disposable.ts
+++ b/src/util/disposable.ts
@@ -4,12 +4,12 @@
  *-----------------------------------------------------------------------------------------------*/
 import * as vscode from 'vscode';
 
-export abstract class Disposable {
+export class Disposable {
   protected disposed = false;
 
   protected disposables: vscode.Disposable[] = [];
 
-  public dispose(): void {
+  dispose(): void {
     if (this.disposed) {
       return;
     }
@@ -17,7 +17,7 @@ export abstract class Disposable {
     disposeAll(this.disposables);
   }
 
-  protected register<T extends vscode.Disposable>(value: T): T {
+  register<T extends vscode.Disposable>(value: T): T {
     if (this.disposed) {
       value.dispose();
     } else {

--- a/src/yaml-support/tkn-editing.ts
+++ b/src/yaml-support/tkn-editing.ts
@@ -1,0 +1,132 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import { TektonYamlType, tektonYaml } from './tkn-yaml';
+import { yamlLocator } from './yaml-locator';
+import { TknElementType, TknStringElement, TknElement } from '../model/common';
+import { TknDocument } from '../model/document';
+import { Pipeline, PipelineTaskRef, PipelineTaskKind, PipelineTaskCondition } from '../model/pipeline/pipeline-model';
+import { kubefsUri } from '../util/tektonresources.virtualfs';
+import { Disposable } from '../util/disposable';
+
+const providersMap = new Map<TektonYamlType, TknTypeDefinitionProvider>();
+
+
+interface TknTypeDefinitionProvider {
+  provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Location | vscode.Location[] | vscode.LocationLink[]>;
+}
+
+export class TknDefinitionProvider implements vscode.DefinitionProvider {
+
+  provideDefinition(document: vscode.TextDocument, position: vscode.Position, token: vscode.CancellationToken): vscode.ProviderResult<vscode.Location | vscode.Location[] | vscode.LocationLink[]> {
+    const type = tektonYaml.isTektonYaml(document);
+    if (type && providersMap.has(type)) {
+      return providersMap.get(type).provideDefinition(document, position, token);
+    }
+    return undefined;
+  }
+
+}
+
+export class PipelineDefinitionProvider implements TknTypeDefinitionProvider {
+
+  provideDefinition(document: vscode.TextDocument, position: vscode.Position): vscode.ProviderResult<vscode.Location | vscode.Location[] | vscode.LocationLink[]> {
+    const element = yamlLocator.getMatchedTknElement(document, position);
+    if (element) {
+      const tknDoc = yamlLocator.findTknDocument(document, position);
+      if (element.parent.type === TknElementType.PIPELINE_TASK_RUN_AFTER) {
+        const pipeTask = this.findPipelineTask((element as TknStringElement).value, tknDoc);
+        if (pipeTask) {
+          return convertTknToLocation(pipeTask, document);
+        }
+      }
+
+      if (element.parent.type === TknElementType.PIPELINE_TASK_INPUT_RESOURCE || element.parent.type === TknElementType.PIPELINE_TASK_OUTPUTS_RESOURCE) {
+        const resDeclaration = this.findResourceDeclaration((element as TknStringElement).value, tknDoc);
+        if (resDeclaration) {
+          return convertTknToLocation(resDeclaration, document);
+        }
+      }
+
+      if (element.parent.type === TknElementType.PIPELINE_TASK_INPUT_RESOURCE_FROM) {
+        const pipeTask = this.findPipelineTask((element as TknStringElement).value, tknDoc);
+        if (pipeTask) {
+          return convertTknToLocation(pipeTask, document);
+        }
+      }
+
+      if (element.parent.type === TknElementType.PIPELINE_TASK_REF) {
+        return this.getTaskRefLocation(element.parent as PipelineTaskRef);
+      }
+
+      if (element.parent.type === TknElementType.PIPELINE_TASK_CONDITION) {
+        return this.getConditionLocation(element.parent as PipelineTaskCondition);
+      }
+    }
+
+    return undefined;
+  }
+
+  private findPipelineTask(taskName: string, doc: TknDocument): TknElement | undefined {
+    const pipeline = doc.getChildren<Pipeline>();
+    let result = undefined;
+    pipeline.spec.tasks.getChildren()?.forEach(el => {
+      if (el.name.value === taskName) {
+        result = el.name;
+      }
+    });
+
+    return result;
+  }
+
+  private findResourceDeclaration(resName: string, doc: TknDocument): TknElement | undefined {
+    const pipeline = doc.getChildren<Pipeline>();
+    for (const param of pipeline.spec.resources?.getChildren()) {
+      if (param.name.value === resName) {
+        return param.name;
+      }
+    }
+
+    return undefined;
+  }
+
+  private getTaskRefLocation(taskRef: PipelineTaskRef): vscode.Location {
+    const type = taskRef.kind.value;
+    return generateLinkForTektonResource(type === PipelineTaskKind.Task ? 'task' : 'clustertask', taskRef.name.value);
+  }
+
+  private getConditionLocation(taskCondition: PipelineTaskCondition): vscode.Location {
+    return generateLinkForTektonResource('conditions', taskCondition.conditionRef.value);
+  }
+}
+
+function generateLinkForTektonResource(resourceType: string, name: string): vscode.Location {
+  const uri = kubefsUri(`${resourceType}/${name}`, 'yaml');
+  return new vscode.Location(uri, new vscode.Position(1, 6)); // just guessing name position
+}
+
+function convertTknToLocation(element: TknElement, doc: vscode.TextDocument): vscode.Location {
+  return new vscode.Location(doc.uri, new vscode.Range(doc.positionAt(element.startPosition), doc.positionAt(element.endPosition)));
+}
+
+const definitionProvider = new TknDefinitionProvider();
+const disposable = new Disposable();
+providersMap.set(TektonYamlType.Pipeline, new PipelineDefinitionProvider());
+
+export function initializeTknEditing(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(disposable);
+  vscode.workspace.textDocuments.forEach(handleTextDocument);
+  disposable.register(vscode.workspace.onDidOpenTextDocument(handleTextDocument));
+}
+
+function handleTextDocument(doc: vscode.TextDocument): void {
+  if (doc.languageId === 'yaml') {
+    const type = tektonYaml.isTektonYaml(doc);
+    if (type && providersMap.has(type)) {
+      disposable.register(vscode.languages.registerDefinitionProvider({ language: 'yaml', pattern: doc.fileName }, definitionProvider))
+    }
+  }
+}

--- a/src/yaml-support/yaml-locator.ts
+++ b/src/yaml-support/yaml-locator.ts
@@ -138,6 +138,14 @@ export class YamlLocator {
     return doc.findElement(offset);
   }
 
+  findTknDocument(textDocument: VirtualDocument, pos: vscode.Position): TknDocument | undefined {
+    const key: string = textDocument.uri.toString();
+    this.ensureCache(key, textDocument);
+    const cacheEntry = this.cache[key];
+    const offset = this.convertPosition(cacheEntry.lineLengths, pos.line, pos.character);
+    return this.getDocumentAtPosition(cacheEntry.tknDocuments, offset);
+  }
+
   private convertPosition(lineLens: number[], lineNumber: number, columnNumber: number): number {
     let pos = 0;
     for (let i = 0; i < lineNumber; i++) {

--- a/test/single-test-run.ts
+++ b/test/single-test-run.ts
@@ -47,11 +47,13 @@ export function run(testsRoots: string, cb: (error: {}, failures?: number) => vo
 
   try {
     mocha.run(failures => {
-      if (failures > 0) {
-        cb(new Error(`${failures} tests failed.`));
-      } else {
-        cb(null, failures);
-      }
+      setTimeout(() => {
+        if (failures > 0) {
+          cb(new Error(`${failures} tests failed.`));
+        } else {
+          cb(null, failures);
+        }
+      }, 100);
     });
 
   } catch (err) {

--- a/test/text-document-mock.ts
+++ b/test/text-document-mock.ts
@@ -4,7 +4,7 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-
+import { EOL } from 'os';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 export class TestTextDocument implements vscode.TextDocument {
@@ -33,13 +33,13 @@ export class TestTextDocument implements vscode.TextDocument {
     throw new Error('Method not implemented.');
   }
   positionAt(offset: number): vscode.Position {
-    const lines = this.text.split('\n');
+    const lines = this.text.split(EOL);
     let sum = 0;
     for (let i = 0; i < lines.length; i++) {
       const str = lines[i];
-      sum += str.length + 1;
+      sum += str.length + EOL.length;
       if (offset <= sum) {
-        return new vscode.Position(i, str.length - (sum - offset) + 1);
+        return new vscode.Position(i, str.length - (sum - offset) + EOL.length);
       }
     }
 

--- a/test/text-document-mock.ts
+++ b/test/text-document-mock.ts
@@ -4,7 +4,6 @@
  *-----------------------------------------------------------------------------------------------*/
 
 import * as vscode from 'vscode';
-import { EOL } from 'os';
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 export class TestTextDocument implements vscode.TextDocument {
@@ -32,14 +31,15 @@ export class TestTextDocument implements vscode.TextDocument {
   offsetAt(position: vscode.Position): number {
     throw new Error('Method not implemented.');
   }
+
   positionAt(offset: number): vscode.Position {
-    const lines = this.text.split(EOL);
+    const lines = this.text.split('\n');
     let sum = 0;
     for (let i = 0; i < lines.length; i++) {
       const str = lines[i];
-      sum += str.length + EOL.length;
+      sum += str.length + 1;
       if (offset <= sum) {
-        return new vscode.Position(i, str.length - (sum - offset) + EOL.length);
+        return new vscode.Position(i, str.length - (sum - offset) + 1);
       }
     }
 

--- a/test/text-document-mock.ts
+++ b/test/text-document-mock.ts
@@ -14,9 +14,11 @@ export class TestTextDocument implements vscode.TextDocument {
   version = 1;
   isDirty: boolean;
   isClosed: boolean;
+  
+  private text;
 
-  constructor(public uri: vscode.Uri, private text: string) {
-
+  constructor(public uri: vscode.Uri, text: string) {
+    this.text = text.replace(/\r\n/gm, '\n'); // normalize end of line
   }
 
   save(): Thenable<boolean> {

--- a/test/text-document-mock.ts
+++ b/test/text-document-mock.ts
@@ -1,0 +1,61 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+export class TestTextDocument implements vscode.TextDocument {
+
+  fileName: string;
+  isUntitled: boolean;
+  languageId: string;
+  version = 1;
+  isDirty: boolean;
+  isClosed: boolean;
+
+  constructor(public uri: vscode.Uri, private text: string) {
+
+  }
+
+  save(): Thenable<boolean> {
+    throw new Error('Method not implemented.');
+  }
+  eol = vscode.EndOfLine.LF;
+  lineCount: number;
+
+  lineAt(position: number | vscode.Position): vscode.TextLine {
+    throw new Error('Method not implemented.');
+  }
+  offsetAt(position: vscode.Position): number {
+    throw new Error('Method not implemented.');
+  }
+  positionAt(offset: number): vscode.Position {
+    const lines = this.text.split('\n');
+    let sum = 0;
+    for (let i = 0; i < lines.length; i++) {
+      const str = lines[i];
+      sum += str.length + 1;
+      if (offset <= sum) {
+        return new vscode.Position(i, str.length - (sum - offset) + 1);
+      }
+    }
+
+    throw new Error('Cannot find position!');
+  }
+  getText(range?: vscode.Range): string {
+    return this.text;
+  }
+  getWordRangeAtPosition(position: vscode.Position, regex?: RegExp): vscode.Range {
+    throw new Error('Method not implemented.');
+  }
+  validateRange(range: vscode.Range): vscode.Range {
+    throw new Error('Method not implemented.');
+  }
+  validatePosition(position: vscode.Position): vscode.Position {
+    throw new Error('Method not implemented.');
+  }
+
+}

--- a/test/yaml-support/tkn-editing.test.ts
+++ b/test/yaml-support/tkn-editing.test.ts
@@ -8,7 +8,6 @@ import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 import * as sinon from 'sinon';
 import * as fs from 'fs-extra';
-import * as nodeFs from 'fs';
 import * as path from 'path';
 import { initializeTknEditing, TknDefinitionProvider } from '../../src/yaml-support/tkn-editing';
 import { tektonYaml, TektonYamlType } from '../../src/yaml-support/tkn-yaml';
@@ -77,9 +76,7 @@ suite('Tekton Editing support', () => {
 
     test('go to task name from runAfter', async () => {
       let yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'), 'utf8');
-      console.error(yaml);
       yaml = yaml.replace(/\r\n/gm, '\n');
-      console.error(yaml);
       const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml);
       isTektonYamlStub.returns(TektonYamlType.Pipeline);
 
@@ -91,8 +88,8 @@ suite('Tekton Editing support', () => {
     });
 
     test('go to task name from inputs resource', async () => {
-      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'));
-      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml.toString());
+      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'), 'utf8');
+      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml);
       isTektonYamlStub.returns(TektonYamlType.Pipeline);
 
       const location = defProvider.provideDefinition(doc, new vscode.Position(32, 22), {} as vscode.CancellationToken) as vscode.Location;
@@ -103,8 +100,8 @@ suite('Tekton Editing support', () => {
     });
 
     test('go to task name from input resource from', async () => {
-      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'));
-      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml.toString());
+      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'), 'utf8');
+      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml);
       isTektonYamlStub.returns(TektonYamlType.Pipeline);
 
       const location = defProvider.provideDefinition(doc, new vscode.Position(80, 18), {} as vscode.CancellationToken) as vscode.Location;
@@ -115,8 +112,8 @@ suite('Tekton Editing support', () => {
     });
 
     test('go to task name from taskRef should return k8s uri to task resource', async () => {
-      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'));
-      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml.toString());
+      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'), 'utf8');
+      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml);
       isTektonYamlStub.returns(TektonYamlType.Pipeline);
 
       const location = defProvider.provideDefinition(doc, new vscode.Position(15, 15), {} as vscode.CancellationToken) as vscode.Location;
@@ -126,8 +123,8 @@ suite('Tekton Editing support', () => {
     });
 
     test('go to task name from taskRef should return k8s uri to task resource', async () => {
-      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'));
-      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml.toString());
+      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'), 'utf8');
+      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml);
       isTektonYamlStub.returns(TektonYamlType.Pipeline);
 
       const location = defProvider.provideDefinition(doc, new vscode.Position(15, 15), {} as vscode.CancellationToken) as vscode.Location;
@@ -137,8 +134,7 @@ suite('Tekton Editing support', () => {
     });
 
     test('go to task name from conditionRef should return k8s uri to conditions resource', async () => {
-      let yaml = nodeFs.readFileSync(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'conditional-pipeline.yaml'), { encoding: 'utf8'});
-      yaml = yaml.replace(/\r\n/gm, '\n');
+      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'conditional-pipeline.yaml'),'utf8');
       const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/conditional-pipeline.yaml'), yaml);
       isTektonYamlStub.returns(TektonYamlType.Pipeline);
 

--- a/test/yaml-support/tkn-editing.test.ts
+++ b/test/yaml-support/tkn-editing.test.ts
@@ -8,6 +8,7 @@ import * as chai from 'chai';
 import * as sinonChai from 'sinon-chai';
 import * as sinon from 'sinon';
 import * as fs from 'fs-extra';
+import * as nodeFs from 'fs';
 import * as path from 'path';
 import { initializeTknEditing, TknDefinitionProvider } from '../../src/yaml-support/tkn-editing';
 import { tektonYaml, TektonYamlType } from '../../src/yaml-support/tkn-yaml';
@@ -133,9 +134,8 @@ suite('Tekton Editing support', () => {
     });
 
     test('go to task name from conditionRef should return k8s uri to conditions resource', async () => {
-      let yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'conditional-pipeline.yaml'), 'utf8');
+      const yaml = nodeFs.readFileSync(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'conditional-pipeline.yaml'), { encoding: 'utf8'});
       console.error(yaml);
-      yaml = yaml.replace(/^\uFEFF/, '');
       const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/conditional-pipeline.yaml'), yaml);
       isTektonYamlStub.returns(TektonYamlType.Pipeline);
 

--- a/test/yaml-support/tkn-editing.test.ts
+++ b/test/yaml-support/tkn-editing.test.ts
@@ -133,8 +133,8 @@ suite('Tekton Editing support', () => {
     });
 
     test('go to task name from conditionRef should return k8s uri to conditions resource', async () => {
-      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'conditional-pipeline.yaml'));
-      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/conditional-pipeline.yaml'), yaml.toString());
+      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'conditional-pipeline.yaml'), 'utf8');
+      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/conditional-pipeline.yaml'), yaml);
       isTektonYamlStub.returns(TektonYamlType.Pipeline);
 
       const location = defProvider.provideDefinition(doc, new vscode.Position(21, 30), {} as vscode.CancellationToken) as vscode.Location;

--- a/test/yaml-support/tkn-editing.test.ts
+++ b/test/yaml-support/tkn-editing.test.ts
@@ -133,7 +133,9 @@ suite('Tekton Editing support', () => {
     });
 
     test('go to task name from conditionRef should return k8s uri to conditions resource', async () => {
-      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'conditional-pipeline.yaml'), 'utf8');
+      let yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'conditional-pipeline.yaml'), 'utf8');
+      console.error(yaml);
+      yaml = yaml.replace(/^\uFEFF/, '');
       const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/conditional-pipeline.yaml'), yaml);
       isTektonYamlStub.returns(TektonYamlType.Pipeline);
 

--- a/test/yaml-support/tkn-editing.test.ts
+++ b/test/yaml-support/tkn-editing.test.ts
@@ -76,7 +76,7 @@ suite('Tekton Editing support', () => {
     });
 
     test('go to task name from runAfter', async () => {
-      let yaml = (await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'))).toString();
+      let yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'), 'utf8');
       console.error(yaml);
       yaml = yaml.replace(/\r\n/gm, '\n');
       console.error(yaml);

--- a/test/yaml-support/tkn-editing.test.ts
+++ b/test/yaml-support/tkn-editing.test.ts
@@ -134,7 +134,8 @@ suite('Tekton Editing support', () => {
     });
 
     test('go to task name from conditionRef should return k8s uri to conditions resource', async () => {
-      const yaml = nodeFs.readFileSync(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'conditional-pipeline.yaml'), { encoding: 'utf8'});
+      let yaml = nodeFs.readFileSync(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'conditional-pipeline.yaml'), { encoding: 'utf8'});
+      yaml = yaml.replace(/\r\n/gm, '\n');
       console.error(yaml);
       const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/conditional-pipeline.yaml'), yaml);
       isTektonYamlStub.returns(TektonYamlType.Pipeline);

--- a/test/yaml-support/tkn-editing.test.ts
+++ b/test/yaml-support/tkn-editing.test.ts
@@ -1,0 +1,148 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as chai from 'chai';
+import * as sinonChai from 'sinon-chai';
+import * as sinon from 'sinon';
+import * as fs from 'fs-extra';
+import * as path from 'path';
+import { initializeTknEditing, TknDefinitionProvider } from '../../src/yaml-support/tkn-editing';
+import { tektonYaml, TektonYamlType } from '../../src/yaml-support/tkn-yaml';
+import { TestTextDocument } from '../text-document-mock';
+import { kubefsUri } from '../../src/util/tektonresources.virtualfs';
+
+const expect = chai.expect;
+chai.use(sinonChai);
+
+suite('Tekton Editing support', () => {
+  const sandbox = sinon.createSandbox();
+  let wsTextDocuments: sinon.SinonStub;
+  let onDidOpenTextDocument: sinon.SinonStub;
+  let registerDefinitionProvider: sinon.SinonStub;
+  let isTektonYamlStub: sinon.SinonStub;
+
+  const extensionContext = { subscriptions: [] } as vscode.ExtensionContext;
+
+  setup(() => {
+    wsTextDocuments = sandbox.stub(vscode.workspace, 'textDocuments').value([]);
+    onDidOpenTextDocument = sandbox.stub(vscode.workspace, 'onDidOpenTextDocument');
+    registerDefinitionProvider = sandbox.stub(vscode.languages, 'registerDefinitionProvider');
+    isTektonYamlStub = sandbox.stub(tektonYaml, 'isTektonYaml');
+  });
+
+  teardown(() => {
+    sandbox.restore();
+  });
+
+  test('initializeTknEditing() should check opened files', () => {
+    wsTextDocuments.value([{ languageId: 'yaml', getText: () => 'Foo', version: 1, uri: vscode.Uri.parse('file:///editing/pipeline/pipeline.yam') } as vscode.TextDocument]);
+    initializeTknEditing(extensionContext);
+    expect(isTektonYamlStub).calledOnce;
+  });
+
+
+  test('initializeTknEditing() should add handler for textDocument opened event', () => {
+    initializeTknEditing(extensionContext);
+    expect(onDidOpenTextDocument).calledOnce
+  });
+
+  test('initializeTknEditing() should register Definition provided for supported yaml', () => {
+    wsTextDocuments.value([{ languageId: 'yaml', getText: () => 'Foo', version: 1, uri: vscode.Uri.parse('file:///editing/pipeline/pipeline.yam') } as vscode.TextDocument]);
+    isTektonYamlStub.returns(TektonYamlType.Pipeline);
+    initializeTknEditing(extensionContext);
+    expect(registerDefinitionProvider).calledOnce;
+  });
+
+  suite('Go to Definition', () => {
+    const defProvider = new TknDefinitionProvider();
+    const mockDocument = { languageId: 'yaml', getText: () => 'Foo', version: 1, uri: vscode.Uri.parse('file:///editing/pipeline/pipeline.yam') } as vscode.TextDocument;
+
+    setup(() => {
+      sandbox.useFakeTimers({
+        now: new Date(),
+        shouldAdvanceTime: true,
+        toFake: ['Date']
+      });
+    });
+
+    test('Definition provider should check tekton yaml type', () => {
+      isTektonYamlStub.returns(TektonYamlType.Pipeline);
+      defProvider.provideDefinition(mockDocument, new vscode.Position(0, 0), {} as vscode.CancellationToken);
+      expect(isTektonYamlStub).calledOnceWith(mockDocument);
+    });
+
+    test('go to task name from runAfter', async () => {
+      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'));
+      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml.toString());
+      isTektonYamlStub.returns(TektonYamlType.Pipeline);
+
+      const location = defProvider.provideDefinition(doc, new vscode.Position(21, 24), {} as vscode.CancellationToken) as vscode.Location;
+
+      expect(location).not.undefined;
+      expect(location.uri.toString()).eqls(doc.uri.toString());
+      expect(location.range).eql(new vscode.Range(new vscode.Position(13, 10), new vscode.Position(13, 29)));
+    });
+
+    test('go to task name from inputs resource', async () => {
+      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'));
+      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml.toString());
+      isTektonYamlStub.returns(TektonYamlType.Pipeline);
+
+      const location = defProvider.provideDefinition(doc, new vscode.Position(32, 22), {} as vscode.CancellationToken) as vscode.Location;
+
+      expect(location).not.undefined;
+      expect(location.uri.toString()).eqls(doc.uri.toString());
+      expect(location.range).eql(new vscode.Range(new vscode.Position(6, 10), new vscode.Position(6, 21)));
+    });
+
+    test('go to task name from input resource from', async () => {
+      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'));
+      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml.toString());
+      isTektonYamlStub.returns(TektonYamlType.Pipeline);
+
+      const location = defProvider.provideDefinition(doc, new vscode.Position(80, 18), {} as vscode.CancellationToken) as vscode.Location;
+
+      expect(location).not.undefined;
+      expect(location.uri.toString()).eqls(doc.uri.toString());
+      expect(location.range).eql(new vscode.Range(new vscode.Position(20, 10), new vscode.Position(20, 28)));
+    });
+
+    test('go to task name from taskRef should return k8s uri to task resource', async () => {
+      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'));
+      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml.toString());
+      isTektonYamlStub.returns(TektonYamlType.Pipeline);
+
+      const location = defProvider.provideDefinition(doc, new vscode.Position(15, 15), {} as vscode.CancellationToken) as vscode.Location;
+
+      expect(location).not.undefined;
+      expect(location.uri.toString()).eqls(kubefsUri('task/unit-tests', 'yaml').toString());
+    });
+
+    test('go to task name from taskRef should return k8s uri to task resource', async () => {
+      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'));
+      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml.toString());
+      isTektonYamlStub.returns(TektonYamlType.Pipeline);
+
+      const location = defProvider.provideDefinition(doc, new vscode.Position(15, 15), {} as vscode.CancellationToken) as vscode.Location;
+
+      expect(location).not.undefined;
+      expect(location.uri.toString()).eqls(kubefsUri('task/unit-tests', 'yaml').toString());
+    });
+
+    test('go to task name from conditionRef should return k8s uri to conditions resource', async () => {
+      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'conditional-pipeline.yaml'));
+      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/conditional-pipeline.yaml'), yaml.toString());
+      isTektonYamlStub.returns(TektonYamlType.Pipeline);
+
+      const location = defProvider.provideDefinition(doc, new vscode.Position(21, 30), {} as vscode.CancellationToken) as vscode.Location;
+
+      expect(location).not.undefined;
+      expect(location.uri.toString()).eqls(kubefsUri('conditions/file-exists', 'yaml').toString());
+    });
+
+  });
+
+});

--- a/test/yaml-support/tkn-editing.test.ts
+++ b/test/yaml-support/tkn-editing.test.ts
@@ -75,8 +75,7 @@ suite('Tekton Editing support', () => {
     });
 
     test('go to task name from runAfter', async () => {
-      let yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'), 'utf8');
-      yaml = yaml.replace(/\r\n/gm, '\n');
+      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'), 'utf8');
       const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml);
       isTektonYamlStub.returns(TektonYamlType.Pipeline);
 

--- a/test/yaml-support/tkn-editing.test.ts
+++ b/test/yaml-support/tkn-editing.test.ts
@@ -76,8 +76,11 @@ suite('Tekton Editing support', () => {
     });
 
     test('go to task name from runAfter', async () => {
-      const yaml = await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'));
-      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml.toString());
+      let yaml = (await fs.readFile(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'pipeline-ordering.yaml'))).toString();
+      console.error(yaml);
+      yaml = yaml.replace(/\r\n/gm, '\n');
+      console.error(yaml);
+      const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/pipeline.yaml'), yaml);
       isTektonYamlStub.returns(TektonYamlType.Pipeline);
 
       const location = defProvider.provideDefinition(doc, new vscode.Position(21, 24), {} as vscode.CancellationToken) as vscode.Location;
@@ -136,7 +139,6 @@ suite('Tekton Editing support', () => {
     test('go to task name from conditionRef should return k8s uri to conditions resource', async () => {
       let yaml = nodeFs.readFileSync(path.join(__dirname, '..', '..', '..', 'test', 'yaml-support', 'conditional-pipeline.yaml'), { encoding: 'utf8'});
       yaml = yaml.replace(/\r\n/gm, '\n');
-      console.error(yaml);
       const doc = new TestTextDocument(vscode.Uri.parse('file:///editing/pipeline/conditional-pipeline.yaml'), yaml);
       isTektonYamlStub.returns(TektonYamlType.Pipeline);
 


### PR DESCRIPTION
This PR add implementation of 'Go to Declaration'(Ctrl+Click) to navigate to declaration.
It currently supports:

- Pipeline task name from `runAfter` - in same file
- Pipeline resource from task input/output resources - in same file
- Pipeline task name from  condition `from` - in same file
- Task/ClusterTask from `taskRef` - open file with declaration
- Condition from `conditionRef`- open file with declaration

Demo:
![ezgif com-video-to-gif (6)](https://user-images.githubusercontent.com/929743/81159610-cd8fba80-8f91-11ea-9563-b7f1654f050d.gif)


Fix: #249 

