### PR TITLE
use rhel8 instead of rhel 7 node (fixes #329)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 
-node('rhel7'){
+node('rhel8'){
 
     stage ('Checkout vscode-tekton code') {
         deleteDir()
@@ -42,7 +42,7 @@ node('rhel7'){
     }
 }
 
-node('rhel7'){
+node('rhel8'){
     if(publishToMarketPlace.equals('true')){
         timeout(time:5, unit:'DAYS') {
             input message:'Approve deployment?', submitter: 'ltulloch,degolovi,yvydolob'


### PR DESCRIPTION
to workaround microsoft/vscode#99492

Signed-off-by: Aurélien Pupier <apupier@redhat.com>