### PR TITLE
Use default shell

### DIFF
--- a/src/util/windowUtils.ts
+++ b/src/util/windowUtils.ts
@@ -21,8 +21,7 @@ export class WindowUtil {
     const options: TerminalOptions = {
       cwd: cwd,
       name: name,
-      env: finalEnv,
-      shellPath: process.platform === 'win32' ? undefined : '/bin/bash'
+      env: finalEnv
     };
     return window.createTerminal(options);
   }

--- a/test/util/window.test.ts
+++ b/test/util/window.test.ts
@@ -42,7 +42,6 @@ suite('Window Utility', () => {
     const options: TerminalOptions = {
       cwd: process.cwd(),
       name: 'terminal',
-      shellPath: process.platform === 'win32' ? undefined : '/bin/bash',
       env: env
     };
     WindowUtil.createTerminal('terminal', process.cwd(), toolLocationDir);


### PR DESCRIPTION
This PR remove hardcoded `/bin/bash` shell for any `tkn` commands, this force to use default system shell.
Fix: #363