### PR TITLE
Publish extension to open-vsx

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,10 +56,10 @@ node('rhel8'){
             }
 
             // Open-vsx Marketplace
-	        sh "npm install -g ovsx"
-	        withCredentials([[$class: 'StringBinding', credentialsId: 'open-vsx-access-token', variable: 'OVSX_TOKEN']]) {
-	        	sh 'ovsx publish -p ${OVSX_TOKEN}' + " ${vsix[0].path}"
-	        }
+            sh "npm install -g ovsx"
+            withCredentials([[$class: 'StringBinding', credentialsId: 'open-vsx-access-token', variable: 'OVSX_TOKEN']]) {
+                sh 'ovsx publish -p ${OVSX_TOKEN}' + " ${vsix[0].path}"
+            }
             archive includes:"**.vsix*"
 
             stage ("Promote the build to stable") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,12 @@ node('rhel8'){
                 def vsix = findFiles(glob: '**.vsix')
                 sh 'vsce publish -p ${TOKEN} --packagePath' + " ${vsix[0].path}"
             }
+
+            // Open-vsx Marketplace
+	        sh "npm install -g ovsx"
+	        withCredentials([[$class: 'StringBinding', credentialsId: 'open-vsx-access-token', variable: 'OVSX_TOKEN']]) {
+	        	sh 'ovsx publish -p ${OVSX_TOKEN}' + " ${vsix[0].path}"
+	        }
             archive includes:"**.vsix*"
 
             stage ("Promote the build to stable") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,8 +50,8 @@ node('rhel8'){
 
         stage ("Publish to Marketplace") {
             unstash 'vsix';
+            def vsix = findFiles(glob: '**.vsix')
             withCredentials([[$class: 'StringBinding', credentialsId: 'vscode_java_marketplace', variable: 'TOKEN']]) {
-                def vsix = findFiles(glob: '**.vsix')
                 sh 'vsce publish -p ${TOKEN} --packagePath' + " ${vsix[0].path}"
             }
 
@@ -63,7 +63,6 @@ node('rhel8'){
             archive includes:"**.vsix*"
 
             stage ("Promote the build to stable") {
-                def vsix = findFiles(glob: '**.vsix')
                 sh "rsync -Pzrlt --rsh=ssh --protocol=28 *.vsix* ${UPLOAD_LOCATION}/stable/vscode-tekton/"
             }
         }


### PR DESCRIPTION
With this PR we will publish vscode-tekton to [open-vsx](http://open-vsx.org/)