### PR TITLE
Send version content in one event

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -201,19 +201,16 @@ async function sendVersionToTelemetry(commandId: string, cmd: string): Promise<v
     }
     for (const [key, value] of Object.entries(version)) {
       if (commandId === 'tkn.version') {
-        sendTknAndKubectlVersionToTelemetry(tektonVersionType[key], `${tektonVersionType[key]}: ${value}`, commandId);
+        telemetryProps[tektonVersionType[key]] = `${value}`;
       } else {
-        sendTknAndKubectlVersionToTelemetry(`kubectl_${key}`, `${key}: v${value['major']}.${value['minor']}`, commandId);
+        telemetryProps[key] = `v${value['major']}.${value['minor']}`;
       }
     }
+    sendTknAndKubectlVersionToTelemetry(commandId, telemetryProps);
   }
 }
 
-async function sendTknAndKubectlVersionToTelemetry(commandId: string, tknKubectlVersion: string, identifierID: string): Promise<void> {
-  const telemetryProps: TelemetryProperties = {
-    identifier: identifierID,
-    version: tknKubectlVersion
-  };
+async function sendTknAndKubectlVersionToTelemetry(commandId: string, telemetryProps: TelemetryProperties): Promise<void> {
   sendTelemetry(commandId, telemetryProps);
 }
 


### PR DESCRIPTION
Added version property in one event for telemetry data.

<img width="473" alt="Screenshot 2021-02-12 at 4 47 56 PM" src="https://user-images.githubusercontent.com/9924513/107762046-625dea80-6d52-11eb-979e-b46c5e5a53a4.png">
