### PR TITLE
Return back "VSCODE_REDHAT_TELEMETRY_DEBUG"

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -38,7 +38,8 @@
 			],
 			"preLaunchTask": "npm: watch",
 			"env": {
-				"VST_DISABLE_COVERAGE": "true"
+				"VST_DISABLE_COVERAGE": "true",
+				"VSCODE_REDHAT_TELEMETRY_DEBUG": "true"
 			}
 		},
 		{
@@ -54,7 +55,10 @@
 			"outFiles": [
 				"${workspaceFolder}/out/test/**/*.js"
 			],
-			"preLaunchTask": "npm: watch"
+			"preLaunchTask": "npm: watch",
+			"env": {
+				"VSCODE_REDHAT_TELEMETRY_DEBUG": "true"
+			}
 		},
 		{
 			"name": "Extension Single Test Debug",
@@ -72,7 +76,8 @@
 			"preLaunchTask": "npm: watch",
 			"env": {
 				"VST_DISABLE_COVERAGE": "true",
-				"VSCODE_SINGLE_TEST": "${relativeFile}"
+				"VSCODE_SINGLE_TEST": "${relativeFile}",
+				"VSCODE_REDHAT_TELEMETRY_DEBUG": "true"
 			}
 		}
 	]


### PR DESCRIPTION
As discussed there: https://github.com/redhat-developer/vscode-tekton/pull/508#discussion_r587342610 
this PR just return `VSCODE_REDHAT_TELEMETRY_DEBUG` env variable to each launch configurations