### PR TITLE
fix: handle endless command execution

### DIFF
--- a/package.json
+++ b/package.json
@@ -677,12 +677,12 @@
       {
         "view": "tektonPipelineExplorerView",
         "contents": "Cluster is not accessible. Use install tool to Start Cluster or any other cluster which is active. \n[Kind](https://kubernetes.io/docs/tasks/tools/#kind)\n[Minikube](https://kubernetes.io/docs/tasks/tools/#minikube)\n[Red Hat OpenShift Local](https://developers.redhat.com/products/openshift-local/overview)",
-        "when": "tekton.cluster"
+        "when": "tekton.cluster.inactive"
       },
       {
         "view": "tektonPipelineExplorerView",
-        "contents": "Tekton Pipeline Operator is not installed. Click the below button to see the documentation for getting started.\n[Tekton pipeline](https://tekton.dev/docs/getting-started/)\n[Tekton Trigger](https://tekton.dev/docs/triggers/install/)",
-        "when": "tekton.pipeline"
+        "contents": "Tekton Pipeline Operator is not installed. Click the below button to see the documentation for getting started.\n[Tekton pipeline](https://tekton.dev/docs/getting-started/)\n[Tekton Triggers](https://tekton.dev/docs/triggers/install/)",
+        "when": "tekton.pipelines.inactive"
       }
     ],
     "menus": {

--- a/src/check-cluster.ts
+++ b/src/check-cluster.ts
@@ -25,8 +25,7 @@ export async function checkOpenShiftCluster(): Promise<clusterVersion> {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return JSON.parse(result?.stdout);
     }
-    return null;
-  } catch (err) {
-    return null;
-  }
+  // eslint-disable-next-line no-empty
+  } catch (err) {}
+  return null
 }

--- a/src/cli-command.ts
+++ b/src/cli-command.ts
@@ -236,8 +236,8 @@ export class Command {
     return newTknCommand('taskrun', 'logs', name, '-f');
   }
 
-  static checkTekton(): CliCommand {
-    return newK8sCommand('auth', 'can-i', 'create', 'pipeline.tekton.dev', '&&', 'kubectl', 'get', 'pipeline.tekton.dev');
+  static checkUserAuthentication(): CliCommand {
+    return newK8sCommand('kubectl', 'get', 'pipeline.tekton.dev');
   }
 
   static hubInstallTask(name: string, version: string): CliCommand {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import * as stream from 'stream';
 import * as JStream from 'jstream';
 import * as events from 'events';
 import { ToolsConfig } from './tools';
-import { ERR_CLUSTER_TIMED_OUT } from './constants';
+import { DEFAULT_EXEC_TIMEOUT, ERR_CLUSTER_TIMED_OUT } from './constants';
 
 export interface CliExitData {
   readonly error: string | Error;
@@ -112,7 +112,7 @@ export class CliImpl implements Cli {
   }
 
   async execute(cmd: CliCommand, opts: SpawnOptions = {
-    timeout: 10000
+    timeout: DEFAULT_EXEC_TIMEOUT
   }): Promise<CliExitData> {
     return new Promise<CliExitData>((resolve) => {
       this.tknChannel.print(cliCommandToString(cmd));

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import * as stream from 'stream';
 import * as JStream from 'jstream';
 import * as events from 'events';
 import { ToolsConfig } from './tools';
+import { ERR_CLUSTER_TIMED_OUT } from './constants';
 
 export interface CliExitData {
   readonly error: string | Error;
@@ -110,7 +111,9 @@ export class CliImpl implements Cli {
     this.tknChannel.show();
   }
 
-  async execute(cmd: CliCommand, opts: SpawnOptions = {}): Promise<CliExitData> {
+  async execute(cmd: CliCommand, opts: SpawnOptions = {
+    timeout: 10000
+  }): Promise<CliExitData> {
     return new Promise<CliExitData>((resolve) => {
       this.tknChannel.print(cliCommandToString(cmd));
       if (opts.windowsHide === undefined) {
@@ -121,7 +124,7 @@ export class CliImpl implements Cli {
       }
       const tkn = spawn(cmd.cliCommand, cmd.cliArguments, opts);
       let stdout = '';
-      let error: string | Error;
+      let error: string | Error = '';
       tkn.stdout.on('data', (data) => {
         stdout += data;
       });
@@ -136,6 +139,12 @@ export class CliImpl implements Cli {
       tkn.on('close', () => {
         resolve({ error, stdout });
       });
+      if (opts.timeout > 0) {
+        setTimeout(() => {
+          error += ERR_CLUSTER_TIMED_OUT;
+          tkn.kill();
+        }, opts.timeout);
+      }
     });
   }
 
@@ -152,7 +161,7 @@ export class CliImpl implements Cli {
   }
 
   executeWatchJSON(cmd: CliCommand, opts: SpawnOptions = {}): JSONWatchProcess {
-    const toolLocation = ToolsConfig.getTknLocation(cmd.cliCommand);
+    const toolLocation = ToolsConfig.getToolLocation(cmd.cliCommand);
     if (toolLocation) {
       // eslint-disable-next-line require-atomic-updates
       cmd.cliCommand = cmd.cliCommand.replace(cmd.cliCommand, `"${toolLocation}"`).replace(new RegExp(`&& ${cmd.cliCommand}`, 'g'), `&& "${toolLocation}"`);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,4 +5,7 @@
 export const IS_CLUSTER_INACTIVE = 'tekton.cluster.inactive';
 export const IS_TEKTON_PIPELINES_INACTIVE = 'tekton.pipelines.inactive';
 
-export const ERR_CLUSTER_TIMED_OUT = 'the cluster took too long to respond'
+export const ERR_CLUSTER_TIMED_OUT = 'the cluster took too long to respond';
+
+export const DEFAULT_EXEC_TIMEOUT = 10000;
+export const CHECK_USER_AUTHENTICATION_TIMEOUT = 5000;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,6 @@
+/*-----------------------------------------------------------------------------------------------
+ *  Copyright (c) Red Hat, Inc. All rights reserved.
+ *  Licensed under the MIT License. See LICENSE file in the project root for license information.
+ *-----------------------------------------------------------------------------------------------*/
+export const IS_TEKTON_CLUSTER_INACTIVE = 'tekton.cluster.inactive';
+export const IS_TEKTON_PIPELINES_INACTIVE = 'tekton.pipeline.inactive';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,5 +2,7 @@
  *  Copyright (c) Red Hat, Inc. All rights reserved.
  *  Licensed under the MIT License. See LICENSE file in the project root for license information.
  *-----------------------------------------------------------------------------------------------*/
-export const IS_TEKTON_CLUSTER_INACTIVE = 'tekton.cluster.inactive';
-export const IS_TEKTON_PIPELINES_INACTIVE = 'tekton.pipeline.inactive';
+export const IS_CLUSTER_INACTIVE = 'tekton.cluster.inactive';
+export const IS_TEKTON_PIPELINES_INACTIVE = 'tekton.pipelines.inactive';
+
+export const ERR_CLUSTER_TIMED_OUT = 'the cluster took too long to respond'

--- a/src/debugger/debug-tree-view.ts
+++ b/src/debugger/debug-tree-view.ts
@@ -54,7 +54,7 @@ export async function watchTaskRunContainer(resourceName: string, resourceType: 
           for (const containerData of taskRunData.status.steps) {
             const debugTaskName = taskRunData.metadata.name;
             const checkDebugStatus = await tkn.execute(Command.isContainerStoppedOnDebug(containerData.container, taskRunData.status.podName, taskRunData.metadata.namespace), process.cwd(), false);
-            if (!debugSessions.get(debugTaskName)?.count && checkDebugStatus.stdout.trim() && checkDebugStatus.stdout.trim().length !== 0) {
+            if (!debugSessions.get(debugTaskName)?.count && checkDebugStatus.stdout && checkDebugStatus.stdout.trim() && checkDebugStatus.stdout.trim().length !== 0) {
               tkn.executeInTerminal(Command.loginToContainer(containerData.container, taskRunData.status.podName, taskRunData.metadata.namespace), debugTaskName);
               debugSessions.set(debugTaskName, {
                 count: true,

--- a/src/tekton/bundle-pipeline-task.ts
+++ b/src/tekton/bundle-pipeline-task.ts
@@ -16,7 +16,7 @@ import * as yaml from 'js-yaml';
 import { Platform } from '../util/platform';
 import { getStderrString } from '../util/stderrstring';
 import { clusterPipelineStatus } from '../util/map-object';
-import { IS_TEKTON_CLUSTER_INACTIVE, IS_TEKTON_PIPELINES_INACTIVE } from '../constants';
+import { IS_CLUSTER_INACTIVE, IS_TEKTON_PIPELINES_INACTIVE } from '../constants';
 
 interface BundleType {
   imageDetail: string;
@@ -26,7 +26,7 @@ interface BundleType {
 }
 
 export async function bundleWizard(): Promise<void> {
-  if (clusterPipelineStatus.get(IS_TEKTON_CLUSTER_INACTIVE)) {
+  if (clusterPipelineStatus.get(IS_CLUSTER_INACTIVE)) {
     window.showWarningMessage('Please check that your cluster is working fine and try again.');
     return;
   }

--- a/src/tekton/bundle-pipeline-task.ts
+++ b/src/tekton/bundle-pipeline-task.ts
@@ -16,6 +16,7 @@ import * as yaml from 'js-yaml';
 import { Platform } from '../util/platform';
 import { getStderrString } from '../util/stderrstring';
 import { clusterPipelineStatus } from '../util/map-object';
+import { IS_TEKTON_CLUSTER_INACTIVE, IS_TEKTON_PIPELINES_INACTIVE } from '../constants';
 
 interface BundleType {
   imageDetail: string;
@@ -25,11 +26,11 @@ interface BundleType {
 }
 
 export async function bundleWizard(): Promise<void> {
-  if (clusterPipelineStatus.get('tekton.cluster')) {
+  if (clusterPipelineStatus.get(IS_TEKTON_CLUSTER_INACTIVE)) {
     window.showWarningMessage('Please check that your cluster is working fine and try again.');
     return;
   }
-  if (clusterPipelineStatus.get('tekton.pipeline')) {
+  if (clusterPipelineStatus.get(IS_TEKTON_PIPELINES_INACTIVE)) {
     window.showWarningMessage('Please install the Pipelines Operator.');
     return;
   }

--- a/src/tekton/diagnostic.ts
+++ b/src/tekton/diagnostic.ts
@@ -22,6 +22,9 @@ export async function showDiagnosticData(diagnostic: TektonNode, commandId?: str
     window.showInformationMessage(`No data available for ${diagnostic.getName()} to Diagnostic Data.`);
     return;
   }
+  if (!result || result.error) {
+    return;
+  }
   const data = JSON.parse(result.stdout);
   if (diagnostic.contextValue === ContextType.PIPELINERUN || diagnostic.contextValue === ContextType.PIPELINERUNCHILDNODE) {
     const taskRun = [];

--- a/src/tkn.ts
+++ b/src/tkn.ts
@@ -601,16 +601,18 @@ export class TknImpl implements Tkn {
     if (command.cliCommand.indexOf('tkn') >= 0) {
       const toolLocation = ToolsConfig.getToolLocation('tkn');
       if (toolLocation) {
-        // eslint-disable-next-line require-atomic-updates
         command.cliCommand = command.cliCommand.replace('tkn', `"${toolLocation}"`).replace(new RegExp('&& tkn', 'g'), `&& "${toolLocation}"`);
       }
     } else {
       const toolConfig = await ToolsConfig.detectOrDownload(command.cliCommand);
-      if (!toolConfig || toolConfig.error == ERR_CLUSTER_TIMED_OUT) {
-        return toolConfig.error;
+      if (toolConfig) {
+        if (toolConfig.error === ERR_CLUSTER_TIMED_OUT) {
+          return toolConfig.error;
+        }
+        if (toolConfig.location) {
+          command.cliCommand = command.cliCommand.replace(command.cliCommand, `"${toolConfig.location}"`).replace(new RegExp(`&& ${command.cliCommand}`, 'g'), `&& "${toolConfig.location}"`);
+        }
       }
-      // eslint-disable-next-line require-atomic-updates
-      command.cliCommand = command.cliCommand.replace(command.cliCommand, `"${toolConfig.location}"`).replace(new RegExp(`&& ${command.cliCommand}`, 'g'), `&& "${toolConfig.location}"`);
     }
     return command;
   }

--- a/src/util/check-cluster-status.ts
+++ b/src/util/check-cluster-status.ts
@@ -6,7 +6,7 @@
 import { commands, TreeItemCollapsibleState } from 'vscode';
 import { CliExitData } from '../cli';
 import { Command } from '../cli-command';
-import { IS_CLUSTER_INACTIVE, IS_TEKTON_PIPELINES_INACTIVE } from '../constants';
+import { CHECK_USER_AUTHENTICATION_TIMEOUT, ERR_CLUSTER_TIMED_OUT, IS_CLUSTER_INACTIVE, IS_TEKTON_PIPELINES_INACTIVE } from '../constants';
 import { ContextType } from '../context-type';
 import { telemetryLog, telemetryLogError } from '../telemetry';
 import { tkn } from '../tkn';
@@ -15,13 +15,12 @@ import { clusterPipelineStatus } from './map-object';
 import { getStderrString } from './stderrstring';
 import { watchTektonResources } from './telemetry-watch-tekton-resource';
 import { watchResources } from './watchResources';
-import { ERR_CLUSTER_TIMED_OUT } from '../constants';
 
 export async function checkClusterStatus(extensionStartUpCheck?: boolean): Promise<TektonNode[]> {
   const result: CliExitData = await tkn.executeWithOptions(
     Command.checkUserAuthentication(), 
     {
-      timeout: 5000,
+      timeout: CHECK_USER_AUTHENTICATION_TIMEOUT,
       ...(process.cwd() && {cwd: process.cwd()})
     }, false
   );

--- a/src/util/check-cluster-status.ts
+++ b/src/util/check-cluster-status.ts
@@ -6,6 +6,7 @@
 import { commands, TreeItemCollapsibleState } from 'vscode';
 import { CliExitData } from '../cli';
 import { Command } from '../cli-command';
+import { IS_TEKTON_CLUSTER_INACTIVE, IS_TEKTON_PIPELINES_INACTIVE } from '../constants';
 import { ContextType } from '../context-type';
 import { telemetryLog, telemetryLogError } from '../telemetry';
 import { tkn } from '../tkn';
@@ -20,59 +21,74 @@ export async function checkClusterStatus(extensionStartUpCheck?: boolean): Promi
     Command.checkTekton(), process.cwd(), false
   );
   if (result.stdout.trim() === 'no') {
-    const tknPrivilegeMsg = 'The current user doesn\'t have the privileges to interact with tekton resources.';
-    const identifier = 'tekton_resource_privileges';
-    watchResources.disableWatch();
-    if (extensionStartUpCheck) {
-      telemetryLog(`${identifier}_startUp`, tknPrivilegeMsg);
-      return;
-    }
-    telemetryLog(identifier, tknPrivilegeMsg);
-    return [new TektonNodeImpl(null, tknPrivilegeMsg, ContextType.TKN_DOWN, this, TreeItemCollapsibleState.None)];
+    return buildErrorNode(
+      'The current user doesn\'t have the privileges to interact with tekton resources.',
+      'tekton_resource_privileges',
+      extensionStartUpCheck
+    );
   }
   if (result.error && getStderrString(result.error).indexOf('You must be logged in to the server (Unauthorized)') > -1) {
-    const tknMessage = 'Please login to the server.';
-    const identifier = 'tekton_login';
-    watchResources.disableWatch();
-    if (extensionStartUpCheck) {
-      telemetryLog(`${identifier}_startUp`, tknMessage);
-      return;
-    }
-    telemetryLog(identifier, tknMessage);
-    return [new TektonNodeImpl(null, tknMessage, ContextType.TKN_DOWN, this, TreeItemCollapsibleState.None)]
+    return buildErrorNode(
+      'Please login to the server.',
+      'tekton_login',
+      extensionStartUpCheck
+    );
   }
   const serverCheck = RegExp('Unable to connect to the server|The connection to the server localhost:8080 was refused');
   if (serverCheck.test(getStderrString(result.error))) {
-    const loginError = 'Unable to connect to OpenShift cluster, is it down?';
-    const identifier = 'problem_connect_cluster';
-    watchResources.disableWatch();
-    if (extensionStartUpCheck) {
-      telemetryLogError(`${identifier}_startUp`, loginError);
-      return;
-    }
-    telemetryLogError(identifier, loginError);
-    clusterPipelineStatus.set('tekton.cluster', true);
+    disableWatchAndLogErrorTelemetry(
+      'Unable to connect to OpenShift cluster, is it down?',
+      'problem_connect_cluster',
+      extensionStartUpCheck
+    );
+    setPipelinesStatus(true, true);
     commands.executeCommand('setContext', 'tekton.pipeline', false);
     commands.executeCommand('setContext', 'tekton.cluster', true);
     return [];
   }
   if (result.error && getStderrString(result.error).indexOf('the server doesn\'t have a resource type \'pipeline\'') > -1) {
-    const message = 'Please install the Pipelines Operator.';
-    const identifier = 'install_pipeline_operator';
-    watchResources.disableWatch();
-    if (extensionStartUpCheck) {
-      telemetryLog(`${identifier}_startUp`, message);
-      return;
-    }
-    telemetryLog(identifier, message);
-    clusterPipelineStatus.set('tekton.cluster', false);
-    clusterPipelineStatus.set('tekton.pipeline', true);
+    disableWatchAndLogTelemetry(
+      'Please install the Pipelines Operator.',
+      'install_pipeline_operator',
+      extensionStartUpCheck
+    );
+    setPipelinesStatus(false, true);
     commands.executeCommand('setContext', 'tekton.cluster', false);
     commands.executeCommand('setContext', 'tekton.pipeline', true);
     return [];
   }
-  clusterPipelineStatus.set('tekton.cluster', false);
-  clusterPipelineStatus.set('tekton.pipeline', false);
+  setPipelinesStatus(false, false);
   await watchTektonResources(extensionStartUpCheck);
   return null;
+}
+
+function setPipelinesStatus(isClusterInactive: boolean, isPipelinesInactive: boolean): void {
+  clusterPipelineStatus.set(IS_TEKTON_CLUSTER_INACTIVE, isClusterInactive);
+  clusterPipelineStatus.set(IS_TEKTON_PIPELINES_INACTIVE, isPipelinesInactive);
+}
+
+function disableWatchAndLogErrorTelemetry(message: string, identifier: string, extensionStartUpCheck?: boolean): void {
+  watchResources.disableWatch();
+  if (extensionStartUpCheck) {
+    telemetryLogError(`${identifier}_startUp`, message);
+    return;
+  }
+  telemetryLogError(identifier, message);
+}
+
+function disableWatchAndLogTelemetry(message: string, identifier: string, extensionStartUpCheck?: boolean): void {
+  watchResources.disableWatch();
+  if (extensionStartUpCheck) {
+    telemetryLog(`${identifier}_startUp`, message);
+    return;
+  }
+  telemetryLog(identifier, message);
+}
+
+function buildErrorNode(message: string, identifier: string, extensionStartUpCheck?: boolean): (TektonNode[] | undefined) {
+  disableWatchAndLogTelemetry(message, identifier, extensionStartUpCheck);
+  if (extensionStartUpCheck) {
+    return undefined;
+  }
+  return [new TektonNodeImpl(null, message, ContextType.TKN_DOWN, this, TreeItemCollapsibleState.None)];
 }

--- a/src/util/list-tekton-resource.ts
+++ b/src/util/list-tekton-resource.ts
@@ -18,7 +18,7 @@ export async function getResourceList(resource: string): Promise<TknPipeline[]> 
 }
 
 async function executeCommand(command: CliCommand): Promise<TknPipeline[]> {
-  if (!ToolsConfig.getTknLocation('kubectl')) return [];
+  if (!ToolsConfig.getToolLocation('kubectl')) return [];
   const result = await tkn.execute(command);
   let data: TknPipeline[] = [];
   try {

--- a/src/util/tekton-vfs.ts
+++ b/src/util/tekton-vfs.ts
@@ -106,13 +106,13 @@ export class TektonVFSProvider implements FileSystemProvider {
     if (taskRegex.test(newResourceName)) {
       newResourceName = newResourceName.replace(`${ContextType.TASK}/`, `${ContextType.TASK}.tekton/`);
     }
-    if (ToolsConfig.getTknLocation('kubectl')) {
+    if (ToolsConfig.getToolLocation('kubectl')) {
       return tkn.execute(newK8sCommand(`-o ${outputFormat} get ${newResourceName}`));
     }
   }
 
   async updateK8sResource(fsPath: string): Promise<CliExitData> {
-    if (ToolsConfig.getTknLocation('kubectl')) {
+    if (ToolsConfig.getToolLocation('kubectl')) {
       return await tkn.execute(newK8sCommand(`apply -f ${fsPath}`));
     }
   }

--- a/src/yaml-support/tkn-conditions-provider.ts
+++ b/src/yaml-support/tkn-conditions-provider.ts
@@ -9,7 +9,7 @@ import { ToolsConfig } from '../tools';
 
 
 export async function getTknConditionsSnippets(): Promise<string[]> {
-  if (!ToolsConfig.getTknLocation('kubectl')) return [];
+  if (!ToolsConfig.getToolLocation('kubectl')) return [];
   const result = await tkn.execute(Command.listConditions());
   let data = [];
   if (result.error) {

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -50,7 +50,7 @@ suite('Cli', () => {
     const result = await p;
 
     expect(spawnStub).calledWith(command.cliCommand, command.cliArguments, options);
-    expect(result).deep.equals({ error: undefined, stdout: stdout });
+    expect(result).deep.equals({ error: '', stdout: stdout });
   });
 
   test('execute passes errors into its exit data', async () => {

--- a/test/tkn.test.ts
+++ b/test/tkn.test.ts
@@ -112,7 +112,9 @@ suite('tkn', () => {
         state: undefined
       };
       toolsStub.restore();
-      toolsStub = sandbox.stub(ToolsConfig, 'detectOrDownload').resolves(path.join('segment1', 'segment2'));
+      toolsStub = sandbox.stub(ToolsConfig, 'detectOrDownload').resolves({
+        location: path.join('segment1', 'segment2')
+      });
       const ctStub = sandbox.stub(WindowUtil, 'createTerminal').returns(termFake);
       await tknCli.executeInTerminal(createCliCommand('tkn'));
       expect(termFake.show).calledOnce;
@@ -1121,16 +1123,16 @@ suite('tkn', () => {
 
   suite('getPipelineNodes', () => {
 
-    let execStub: sinon.SinonStub;
+    let execWithOptionsStub: sinon.SinonStub;
     let commandsStub: sinon.SinonStub;
 
     setup(() => {
       commandsStub = sandbox.stub(commands, 'executeCommand');
-      execStub = sandbox.stub(tknCli, 'execute');
+      execWithOptionsStub = sandbox.stub(tknCli, 'executeWithOptions');
     });
 
     test('show warning message if user doesn\'t have the privileges to interact with tekton resources', async () => {
-      execStub.onFirstCall().resolves({ error: undefined, stdout: 'no' });
+      execWithOptionsStub.onFirstCall().resolves({ error: undefined, stdout: 'no' });
       const result = await tknCli.getPipelineNodes();
       assert.equal(result[0].getName(), 'The current user doesn\'t have the privileges to interact with tekton resources.');
     });
@@ -1138,7 +1140,7 @@ suite('tkn', () => {
     test('show warning message if pipelines operator is not installed', async () => {
       commandsStub.onFirstCall().resolves(false);
       commandsStub.onSecondCall().resolves(true);
-      execStub.onFirstCall().resolves({ error: 'error: the server doesn\'t have a resource type \'pipeline\'', stdout: '' });
+      execWithOptionsStub.onFirstCall().resolves({ error: 'error: the server doesn\'t have a resource type \'pipeline\'', stdout: '' });
       await tknCli.getPipelineNodes();
       expect(commandsStub).calledTwice;
     });

--- a/test/tkn.test.ts
+++ b/test/tkn.test.ts
@@ -38,7 +38,7 @@ suite('tkn', () => {
     sandbox.stub(telemetry, 'telemetryLogError');
     sandbox.stub(ToolsConfig, 'getVersion').resolves('0.2.0');
     execStubCli = sandbox.stub(CliImpl.prototype, 'execute').resolves();
-    sandbox.stub(ToolsConfig, 'getTknLocation').returns('kubectl');
+    sandbox.stub(ToolsConfig, 'getToolLocation').returns('kubectl');
   });
 
   teardown(() => {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -35,8 +35,8 @@ suite('tool configuration', () => {
       sb.stub(CliImpl.prototype, 'execute').resolves(testData);
       sb.stub(fsex, 'pathExists').resolves(true);
 
-      const result: string = await ToolsConfig.getVersion('tkn');
-      assert.equal(result, '0.2.0');
+      const result = await ToolsConfig.getVersion('tkn');
+      assert.equal(result.version, '0.2.0');
     });
 
     test('returns version number with expected output when version number start with "v"', async () => {
@@ -44,8 +44,8 @@ suite('tool configuration', () => {
       sb.stub(CliImpl.prototype, 'execute').resolves(testData);
       sb.stub(fsex, 'pathExists').resolves(true);
 
-      const result: string = await ToolsConfig.getVersion('tkn');
-      assert.equal(result, '0.2.0');
+      const result = await ToolsConfig.getVersion('tkn');
+      assert.equal(result.version, '0.2.0');
     });
 
     test('returns version undefined for unexpected output', async () => {
@@ -53,8 +53,8 @@ suite('tool configuration', () => {
       sb.stub(CliImpl.prototype, 'execute').resolves(invalidData);
       sb.stub(fsex, 'pathExists').resolves(true);
 
-      const result: string = await ToolsConfig.getVersion('tkn');
-      assert.equal(result, undefined);
+      const result = await ToolsConfig.getVersion('tkn');
+      assert.equal(result.version, undefined);
     });
 
     test('returns version undefined for not existing tool', async () => {
@@ -62,8 +62,8 @@ suite('tool configuration', () => {
       sb.stub(CliImpl.prototype, 'execute').resolves(invalidData);
       sb.stub(fsex, 'pathExists').resolves(false);
 
-      const result: string = await ToolsConfig.getVersion('odo');
-      assert.equal(result, undefined);
+      const result = await ToolsConfig.getVersion('odo');
+      assert.equal(result.version, undefined);
     });
 
     test('returns version undefined for tool that does not support version parameter', async () => {
@@ -71,8 +71,8 @@ suite('tool configuration', () => {
       sb.stub(CliImpl.prototype, 'execute').resolves(invalidData);
       sb.stub(fsex, 'pathExists').resolves(true);
 
-      const result: string = await ToolsConfig.getVersion('tkn');
-      assert.equal(result, undefined);
+      const result = await ToolsConfig.getVersion('tkn');
+      assert.equal(result.version, undefined);
     });
   });
 

--- a/test/util/check-ref-resource.test.ts
+++ b/test/util/check-ref-resource.test.ts
@@ -66,7 +66,7 @@ suite('Reference Task/ClusterTask', () => {
 
   setup(() => {
     execStub = sandbox.stub(TknImpl.prototype, 'execute').resolves();
-    sandbox.stub(ToolsConfig, 'getTknLocation').returns('kubectl');
+    sandbox.stub(ToolsConfig, 'getToolLocation').returns('kubectl');
   });
 
   teardown(() => {

--- a/test/util/tekton-vfs.test.ts
+++ b/test/util/tekton-vfs.test.ts
@@ -60,7 +60,7 @@ suite('Tekton VFS Provider', () => {
       writeFileStub = sandbox.stub(fsx, 'writeFile');
       ensureFileStub = sandbox.stub(fsx, 'ensureFile');
       statStub = sandbox.stub(fsx, 'stat');
-      sandbox.stub(ToolsConfig, 'getTknLocation').returns('1.18.0');
+      sandbox.stub(ToolsConfig, 'getToolLocation').returns('1.18.0');
     });
 
     test('extractResourceAndFormat should return resource and format', () => {

--- a/test/yaml-support/tasks-provider.test.ts
+++ b/test/yaml-support/tasks-provider.test.ts
@@ -19,7 +19,7 @@ suite('Task provider', () => {
 
   setup(() => {
     execStub = sandbox.stub(tknCli, 'execute');
-    sandbox.stub(ToolsConfig, 'getTknLocation').returns('kubectl');
+    sandbox.stub(ToolsConfig, 'getToolLocation').returns('kubectl');
   });
 
   teardown(() => {

--- a/test/yaml-support/tkn-condition-provider.test.ts
+++ b/test/yaml-support/tkn-condition-provider.test.ts
@@ -19,7 +19,7 @@ suite('ConditionRef provider', () => {
 
   setup(() => {
     tknExecute = sandbox.stub(tkn, 'execute');
-    sandbox.stub(ToolsConfig, 'getTknLocation').returns('kubectl');
+    sandbox.stub(ToolsConfig, 'getToolLocation').returns('kubectl');
   });
 
   teardown(() => {


### PR DESCRIPTION
This patch covers
1) some refactoring/renaming as i found some part very confusing by only reading the code
2) it resolves https://github.com/redhat-developer/vscode-tekton/issues/731 . I added a timeout so if a command run for too long it is killed and users are informed something is not right and they should verify their cluster