### PR TITLE
fix: remove large range value  for kubectl

### DIFF
--- a/src/tools.json
+++ b/src/tools.json
@@ -4,7 +4,7 @@
     "vendor": "Google",
     "name": "kubectl",
     "version": "1.25.3",
-    "versionRange": "1.17.0 - 1.25.3",
+    "versionRange": "1.25.3",
     "versionRangeLabel": "v1.25.3",
     "dlFileName": "kubectl",
     "cmdFileName": "kubectl",


### PR DESCRIPTION
i didn't remove the flag, just edit its value to make users use the latest version
it resolves https://github.com/redhat-developer/vscode-tekton/issues/729